### PR TITLE
feat: add --all flag to include all declarations without @[blueprint]

### DIFF
--- a/Architect/Content.lean
+++ b/Architect/Content.lean
@@ -2,7 +2,7 @@ import Architect.Basic
 import Architect.Command
 
 
-open Lean Elab
+open Lean Elab Meta
 
 namespace Architect
 
@@ -33,19 +33,90 @@ def BlueprintContent.order (l r : BlueprintContent) : Bool :=
   | some _, none => true
   | _, _ => false
 
-/-- Get blueprint contents of the current module. -/
+/-- Whether a constant should be auto-included in the blueprint in `--all` mode.
+Uses the same filtering as Lean's `allowCompletion` (IDE completion, `exact?`, etc.)
+plus a declaration-ranges check (as in doc-gen4) to skip auto-generated declarations.
+Only includes theorems, definitions, and inductives. -/
+private def shouldAutoInclude (name : Name) : CoreM Bool := do
+  let env ← getEnv
+  -- Use Lean's canonical blacklist (isInternal, isAuxRecursor, isNoConfusion, isRec, isMatcher)
+  if !allowCompletion env name then return false
+  -- Skip private declarations
+  if isPrivateName name then return false
+  -- Skip if already tagged with @[blueprint]
+  if (blueprintExt.find? env name).isSome then return false
+  -- Skip declarations without source location (auto-generated, per doc-gen4)
+  if (← findDeclarationRangesCore? name).isNone then return false
+  -- Only include theorems, definitions, and inductives
+  return match env.find? name with
+    | some (.thmInfo _) => true
+    | some (.defnInfo _) => true
+    | some (.inductInfo _) => true
+    | _ => false
+
+/-- Create a default blueprint `Node` for a constant that was not explicitly tagged
+with `@[blueprint]`. Used in `--all` mode. Uses the doc-string as the statement text. -/
+private def mkDefaultNode (env : Environment) (name : Name) (docString : String := "") : Node :=
+  let isTheorem := match env.find? name with
+    | some (.thmInfo _) => true
+    | _ => false
+  {
+    name
+    latexLabel := name.toString
+    statement := {
+      text := docString
+      uses := #[]
+      excludes := #[]
+      usesLabels := #[]
+      excludesLabels := #[]
+      latexEnv := if isTheorem then "theorem" else "definition"
+    }
+    proof := if isTheorem then some {
+      text := ""
+      uses := #[]
+      excludes := #[]
+      usesLabels := #[]
+      excludesLabels := #[]
+      latexEnv := "proof"
+    } else none
+    notReady := false
+    discussion := none
+    title := none
+  }
+
+/-- Get auto-included blueprint nodes for constants in a specific module.
+Only enumerates constants belonging to the given module index — does not
+traverse the full environment. -/
+private def getAutoIncludedNodes (modIdx : ModuleIdx) : CoreM (Array BlueprintContent) := do
+  let env ← getEnv
+  let constNames := env.header.moduleData[modIdx.toNat]!.constNames
+  let mut nodes : Array BlueprintContent := #[]
+  let env ← getEnv
+  for name in constNames do
+    if ← shouldAutoInclude name then
+      let docString := (← findDocString? env name).getD ""
+      let node := mkDefaultNode env name docString
+      nodes := nodes.push (.node (← node.toNodeWithPos))
+  return nodes
+
+/-- Get blueprint contents of the current module.
+This is only used from `#show_blueprint` / `#show_blueprint_json` commands within a Lean file.
+The extraction executable uses `getBlueprintContents` for all modules, since it loads them
+as imports. -/
 def getMainModuleBlueprintContents : CoreM (Array BlueprintContent) := do
   let env ← getEnv
   let nodes ← (blueprintExt.getEntries env).toArray.mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
   let modDocs := (getMainModuleBlueprintDoc env).toArray.map BlueprintContent.modDoc
   return (nodes ++ modDocs).qsort BlueprintContent.order
 
-/-- Get blueprint contents of an imported module. -/
-def getBlueprintContents (module : Name) : CoreM (Array BlueprintContent) := do
+/-- Get blueprint contents of an imported module.
+Only enumerates constants belonging to the specified module. -/
+def getBlueprintContents (module : Name) (all : Bool := false) : CoreM (Array BlueprintContent) := do
   let env ← getEnv
   let some modIdx := env.getModuleIdx? module | return #[]
   let nodes ← (blueprintExt.getModuleEntries env modIdx).mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
+  let autoNodes ← if all then getAutoIncludedNodes modIdx else pure #[]
   let modDocs := (getModuleBlueprintDoc? env module).getD #[] |>.map BlueprintContent.modDoc
-  return (nodes ++ modDocs).qsort BlueprintContent.order
+  return (nodes ++ autoNodes ++ modDocs).qsort BlueprintContent.order
 
 end Architect

--- a/Architect/Content.lean
+++ b/Architect/Content.lean
@@ -86,16 +86,20 @@ private def mkDefaultNode (env : Environment) (name : Name) (docString : String 
 
 /-- Get auto-included blueprint nodes for constants in a specific module.
 Only enumerates constants belonging to the given module index — does not
-traverse the full environment. -/
+traverse the full environment. Registers nodes in the blueprint environment
+extensions so that downstream rendering (dependency inference, sorry detection,
+`\lean{}` links) works correctly. -/
 private def getAutoIncludedNodes (modIdx : ModuleIdx) : CoreM (Array BlueprintContent) := do
   let env ← getEnv
   let constNames := env.header.moduleData[modIdx.toNat]!.constNames
   let mut nodes : Array BlueprintContent := #[]
-  let env ← getEnv
   for name in constNames do
     if ← shouldAutoInclude name then
-      let docString := (← findDocString? env name).getD ""
-      let node := mkDefaultNode env name docString
+      let docString := (← findDocString? (← getEnv) name).getD ""
+      let node := mkDefaultNode (← getEnv) name docString
+      -- Register in env extensions so rendering can find these nodes
+      blueprintExt.add name node
+      modifyEnv fun env => addLeanNameOfLatexLabel env node.latexLabel name
       nodes := nodes.push (.node (← node.toNodeWithPos))
   return nodes
 

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -31,11 +31,11 @@ def runEnvOfImports (imports : Array Name) (options : Options) (x : CoreM α) : 
   Prod.fst <$> x.toIO config { env }
 
 /-- Outputs the blueprint of a module. -/
-def latexOutputOfImportModule (module : Name) (options : Options) : IO LatexOutput :=
-  runEnvOfImports #[module] options (moduleToLatexOutput module)
+def latexOutputOfImportModule (module : Name) (options : Options) (all : Bool := false) : IO LatexOutput :=
+  runEnvOfImports #[module] options (moduleToLatexOutput module all)
 
 /-- Outputs the JSON data for the blueprint of a module. -/
-def jsonOfImportModule (module : Name) (options : Options) : IO Json :=
-  runEnvOfImports #[module] options (moduleToJson module)
+def jsonOfImportModule (module : Name) (options : Options) (all : Bool := false) : IO Json :=
+  runEnvOfImports #[module] options (moduleToJson module all)
 
 end Architect

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -220,8 +220,8 @@ private def moduleToLatexOutputAux (module : Name) (contents : Array BlueprintCo
   return { header, artifacts }
 
 /-- Convert imported module to LaTeX (header file, artifact files). -/
-def moduleToLatexOutput (module : Name) : CoreM LatexOutput := do
-  let contents ← getBlueprintContents module
+def moduleToLatexOutput (module : Name) (all : Bool := false) : CoreM LatexOutput := do
+  let contents ← getBlueprintContents module all
   moduleToLatexOutputAux module contents
 
 /-- Convert current module to LaTeX (header file, artifact files). -/
@@ -286,9 +286,9 @@ def BlueprintContent.toJson : BlueprintContent → Json
   | .node n => json% {"type": "node", "data": $(n.toJson)}
   | .modDoc d => json% {"type": "moduleDoc", "data": $(d.doc)}
 
-def moduleToJson (module : Name) : CoreM Json := do
+def moduleToJson (module : Name) (all : Bool := false) : CoreM Json := do
   return Json.arr <|
-    (← getBlueprintContents module).map BlueprintContent.toJson
+    (← getBlueprintContents module all).map BlueprintContent.toJson
 
 def mainModuleToJson : CoreM Json := do
   return Json.arr <|

--- a/ArchitectTest/BlueprintAll/Basic.lean
+++ b/ArchitectTest/BlueprintAll/Basic.lean
@@ -1,0 +1,24 @@
+/-!
+Test for `--all` mode: no `@[blueprint]` attributes anywhere.
+This file defines basic types and is imported by `BlueprintAll.Theorems`.
+-/
+
+set_option warn.sorry false
+
+/-- A simple type for testing. -/
+inductive Color where
+  | red : Color
+  | blue : Color
+
+namespace Color
+
+/-- Mix two colors. -/
+def mix (a b : Color) : Color :=
+  match a, b with
+  | red, red => red
+  | blue, blue => blue
+  | _, _ => red
+
+private def helperFn : Color := .red
+
+end Color

--- a/ArchitectTest/BlueprintAll/Theorems.lean
+++ b/ArchitectTest/BlueprintAll/Theorems.lean
@@ -17,4 +17,9 @@ theorem mix_comm (a b : Color) : mix a b = mix b a := by
 theorem mix_assoc (a b c : Color) : mix (mix a b) c = mix a (mix b c) := by
   sorry
 
+/-- Mixing blue then red equals mixing red then blue.
+This theorem uses `mix_comm` in its proof, testing dependency inference. -/
+theorem mix_blue_red_comm : mix .blue .red = mix .red .blue :=
+  mix_comm ..
+
 end Color

--- a/ArchitectTest/BlueprintAll/Theorems.lean
+++ b/ArchitectTest/BlueprintAll/Theorems.lean
@@ -1,0 +1,20 @@
+import ArchitectTest.BlueprintAll.Basic
+
+/-!
+Theorems about `Color.mix`, importing `Basic`. No `@[blueprint]` attributes.
+Tests that `--all` correctly picks up theorems and tracks sorry status.
+-/
+
+set_option warn.sorry false
+
+namespace Color
+
+/-- Mixing is commutative. -/
+theorem mix_comm (a b : Color) : mix a b = mix b a := by
+  cases a <;> cases b <;> rfl
+
+/-- Associativity of mixing (sorry'd to test leanOk detection). -/
+theorem mix_assoc (a b c : Color) : mix (mix a b) c = mix a (mix b c) := by
+  sorry
+
+end Color

--- a/Main.lean
+++ b/Main.lean
@@ -19,14 +19,15 @@ def runSingleCmd (p : Parsed) : IO UInt32 := do
   let baseDir := outputBaseDir buildDir
   let module := p.positionalArg! "module" |>.as! String |>.toName
   let isJson := p.hasFlag "json"
+  let all := p.hasFlag "all"
   let options : LeanOptions ← match p.flag? "options" with
     | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
     | none => pure (∅ : LeanOptions)
   if isJson then
-    let json ← jsonOfImportModule module options.toOptions
+    let json ← jsonOfImportModule module options.toOptions all
     outputJsonResults baseDir module json
   else
-    let latexOutput ← latexOutputOfImportModule module options.toOptions
+    let latexOutput ← latexOutputOfImportModule module options.toOptions all
     discard <| outputLatexResults baseDir module latexOutput
   return 0
 
@@ -50,6 +51,7 @@ def singleCmd := `[Cli|
 
   FLAGS:
     j, json; "Output JSON instead of LaTeX."
+    a, all; "Include all theorems, definitions, and inductives in the blueprint, even without @[blueprint] attributes."
     b, build : String; "Build directory."
     o, options : String; "LeanOptions in JSON to pass to running the module."
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -51,14 +51,6 @@ module_facet blueprint (mod : Module) : Unit := do
 module_facet blueprintJson (mod : Module) : Unit := do
   buildModuleBlueprint mod "json" #["--json"]
 
-/-- A facet to extract the blueprint for a module, including all declarations (no `@[blueprint]` needed). -/
-module_facet blueprintAll (mod : Module) : Unit := do
-  buildModuleBlueprint mod "tex" #["--all"]
-
-/-- A facet to extract JSON data of blueprint for a module, including all declarations. -/
-module_facet blueprintAllJson (mod : Module) : Unit := do
-  buildModuleBlueprint mod "json" #["--json", "--all"]
-
 def buildLibraryBlueprint (lib : LeanLib) (moduleFacet : Lean.Name) (ext : String) (extractArgs : Array String) : FetchM (Job Unit) := do
   let mods ← (← lib.modules.fetch).await
   let moduleJobs := Job.collectArray <| ← mods.mapM (fetch <| ·.facet moduleFacet)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -51,6 +51,14 @@ module_facet blueprint (mod : Module) : Unit := do
 module_facet blueprintJson (mod : Module) : Unit := do
   buildModuleBlueprint mod "json" #["--json"]
 
+/-- A facet to extract the blueprint for a module, including all declarations (no `@[blueprint]` needed). -/
+module_facet blueprintAll (mod : Module) : Unit := do
+  buildModuleBlueprint mod "tex" #["--all"]
+
+/-- A facet to extract JSON data of blueprint for a module, including all declarations. -/
+module_facet blueprintAllJson (mod : Module) : Unit := do
+  buildModuleBlueprint mod "json" #["--json", "--all"]
+
 def buildLibraryBlueprint (lib : LeanLib) (moduleFacet : Lean.Name) (ext : String) (extractArgs : Array String) : FetchM (Job Unit) := do
   let mods ← (← lib.modules.fetch).await
   let moduleJobs := Job.collectArray <| ← mods.mapM (fetch <| ·.facet moduleFacet)

--- a/test_blueprint_all.sh
+++ b/test_blueprint_all.sh
@@ -28,8 +28,13 @@ if [ "$names" != "Color Color.mix" ]; then
   exit 1
 fi
 
-# Private helperFn should NOT be included
-if python3 -c "import json; d=json.load(open('$basic_json')); assert any('helper' in n['data']['name'] for n in d)" 2>/dev/null; then
+# Private helperFn should NOT be included (check exact name set, not substring)
+if python3 -c "
+import json
+d = json.load(open('$basic_json'))
+names = {n['data']['name'] for n in d}
+assert 'Color.helperFn' in names or any('helper' in n for n in names)
+" 2>/dev/null; then
   echo "FAIL: Private helperFn should not be included"
   exit 1
 fi
@@ -40,17 +45,17 @@ lake env .lake/build/bin/extract_blueprint single --json --all --build .lake/bui
 
 theorems_json=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.json"
 
-# Should contain mix_comm and mix_assoc (2 nodes), NOT Color or Color.mix from Basic
+# Should contain 3 nodes, NOT Color or Color.mix from Basic
 count=$(python3 -c "import json; d=json.load(open('$theorems_json')); print(len(d))")
-if [ "$count" != "2" ]; then
-  echo "FAIL: Theorems module should have 2 nodes, got $count"
+if [ "$count" != "3" ]; then
+  echo "FAIL: Theorems module should have 3 nodes, got $count"
   cat "$theorems_json"
   exit 1
 fi
 
 names=$(python3 -c "import json; d=json.load(open('$theorems_json')); print(' '.join(sorted(n['data']['name'] for n in d)))")
-if [ "$names" != "Color.mix_assoc Color.mix_comm" ]; then
-  echo "FAIL: Theorems module should have Color.mix_comm and Color.mix_assoc, got: $names"
+if [ "$names" != "Color.mix_assoc Color.mix_blue_red_comm Color.mix_comm" ]; then
+  echo "FAIL: Theorems module should have mix_comm, mix_assoc, mix_blue_red_comm, got: $names"
   exit 1
 fi
 
@@ -64,30 +69,51 @@ if [ "$count" != "0" ]; then
   exit 1
 fi
 
-echo "Testing LaTeX output (sorry detection)..."
+echo "Testing LaTeX output (sorry detection and dependency inference)..."
 rm -rf .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.tex .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts
 lake env .lake/build/bin/extract_blueprint single --all --build .lake/build ArchitectTest.BlueprintAll.Theorems
 
-# mix_assoc is sorry'd — proof should NOT have \leanok
-assoc_tex=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts/Color.mix_assoc.tex"
-if grep -A1 'begin{proof}' "$assoc_tex" | grep -q '\\leanok'; then
+artifacts=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts"
+
+# mix_assoc is sorry'd — its proof block should NOT contain \leanok
+assoc_proof=$(python3 -c "
+import re
+tex = open('$artifacts/Color.mix_assoc.tex').read()
+proof = re.search(r'\\\\begin\{proof\}(.*?)\\\\end\{proof\}', tex, re.DOTALL)
+print(proof.group(1) if proof else '')
+")
+if echo "$assoc_proof" | grep -q '\\leanok'; then
   echo "FAIL: mix_assoc proof should NOT have \\leanok (it has sorry)"
-  cat "$assoc_tex"
+  cat "$artifacts/Color.mix_assoc.tex"
   exit 1
 fi
 
-# mix_comm is proved — proof SHOULD have \leanok
-comm_tex=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts/Color.mix_comm.tex"
-if ! grep -A1 'begin{proof}' "$comm_tex" | grep -q '\\leanok'; then
+# mix_comm is proved — its proof block SHOULD contain \leanok
+comm_proof=$(python3 -c "
+import re
+tex = open('$artifacts/Color.mix_comm.tex').read()
+proof = re.search(r'\\\\begin\{proof\}(.*?)\\\\end\{proof\}', tex, re.DOTALL)
+print(proof.group(1) if proof else '')
+")
+if ! echo "$comm_proof" | grep -q '\\leanok'; then
   echo "FAIL: mix_comm proof SHOULD have \\leanok (it is proved)"
-  cat "$comm_tex"
+  cat "$artifacts/Color.mix_comm.tex"
   exit 1
 fi
 
 # \lean{} should not be empty
-if grep -q '\\lean{}' "$assoc_tex"; then
+if grep -q '\\lean{}' "$artifacts/Color.mix_assoc.tex"; then
   echo "FAIL: \\lean{} should not be empty"
-  cat "$assoc_tex"
+  cat "$artifacts/Color.mix_assoc.tex"
+  exit 1
+fi
+
+# Dependency inference: mix_blue_red_comm uses mix_comm in its proof
+# The proof block should contain \uses{Color.mix_comm}
+dep_tex="$artifacts/Color.mix_blue_red_comm.tex"
+if ! grep -q '\\uses{Color.mix_comm}' "$dep_tex"; then
+  echo "FAIL: mix_blue_red_comm proof should have \\uses{Color.mix_comm} (dependency inference)"
+  cat "$dep_tex"
   exit 1
 fi
 

--- a/test_blueprint_all.sh
+++ b/test_blueprint_all.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Test that --all mode correctly extracts declarations without @[blueprint] attributes.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "Building test modules..."
+lake build ArchitectTest.BlueprintAll.Basic ArchitectTest.BlueprintAll.Theorems
+
+echo "Testing --all on Basic module..."
+rm -f .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Basic.json
+lake env .lake/build/bin/extract_blueprint single --json --all --build .lake/build ArchitectTest.BlueprintAll.Basic
+
+basic_json=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Basic.json"
+
+# Should contain Color and Color.mix (2 nodes)
+count=$(python3 -c "import json; d=json.load(open('$basic_json')); print(len(d))")
+if [ "$count" != "2" ]; then
+  echo "FAIL: Basic module should have 2 nodes, got $count"
+  cat "$basic_json"
+  exit 1
+fi
+
+# Should contain Color and Color.mix by name
+names=$(python3 -c "import json; d=json.load(open('$basic_json')); print(' '.join(sorted(n['data']['name'] for n in d)))")
+if [ "$names" != "Color Color.mix" ]; then
+  echo "FAIL: Basic module should have Color and Color.mix, got: $names"
+  exit 1
+fi
+
+# Private helperFn should NOT be included
+if python3 -c "import json; d=json.load(open('$basic_json')); assert any('helper' in n['data']['name'] for n in d)" 2>/dev/null; then
+  echo "FAIL: Private helperFn should not be included"
+  exit 1
+fi
+
+echo "Testing --all on Theorems module..."
+rm -f .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.json
+lake env .lake/build/bin/extract_blueprint single --json --all --build .lake/build ArchitectTest.BlueprintAll.Theorems
+
+theorems_json=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.json"
+
+# Should contain mix_comm and mix_assoc (2 nodes), NOT Color or Color.mix from Basic
+count=$(python3 -c "import json; d=json.load(open('$theorems_json')); print(len(d))")
+if [ "$count" != "2" ]; then
+  echo "FAIL: Theorems module should have 2 nodes, got $count"
+  cat "$theorems_json"
+  exit 1
+fi
+
+names=$(python3 -c "import json; d=json.load(open('$theorems_json')); print(' '.join(sorted(n['data']['name'] for n in d)))")
+if [ "$names" != "Color.mix_assoc Color.mix_comm" ]; then
+  echo "FAIL: Theorems module should have Color.mix_comm and Color.mix_assoc, got: $names"
+  exit 1
+fi
+
+echo "Testing without --all (should be empty)..."
+rm -f .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.json
+lake env .lake/build/bin/extract_blueprint single --json --build .lake/build ArchitectTest.BlueprintAll.Theorems
+
+count=$(python3 -c "import json; d=json.load(open('$theorems_json')); print(len(d))")
+if [ "$count" != "0" ]; then
+  echo "FAIL: Without --all, should have 0 nodes, got $count"
+  exit 1
+fi
+
+echo "Testing LaTeX output (sorry detection)..."
+rm -rf .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.tex .lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts
+lake env .lake/build/bin/extract_blueprint single --all --build .lake/build ArchitectTest.BlueprintAll.Theorems
+
+# mix_assoc is sorry'd — proof should NOT have \leanok
+assoc_tex=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts/Color.mix_assoc.tex"
+if grep -A1 'begin{proof}' "$assoc_tex" | grep -q '\\leanok'; then
+  echo "FAIL: mix_assoc proof should NOT have \\leanok (it has sorry)"
+  cat "$assoc_tex"
+  exit 1
+fi
+
+# mix_comm is proved — proof SHOULD have \leanok
+comm_tex=".lake/build/blueprint/module/ArchitectTest/BlueprintAll/Theorems.artifacts/Color.mix_comm.tex"
+if ! grep -A1 'begin{proof}' "$comm_tex" | grep -q '\\leanok'; then
+  echo "FAIL: mix_comm proof SHOULD have \\leanok (it is proved)"
+  cat "$comm_tex"
+  exit 1
+fi
+
+# \lean{} should not be empty
+if grep -q '\\lean{}' "$assoc_tex"; then
+  echo "FAIL: \\lean{} should not be empty"
+  cat "$assoc_tex"
+  exit 1
+fi
+
+echo "All tests passed!"


### PR DESCRIPTION
## Summary

Adds an `--all` flag to `extract_blueprint single` that includes all user-defined theorems, definitions, and inductives in the blueprint, without requiring explicit `@[blueprint]` attributes on each declaration.

This enables using LeanArchitect as a **purely external tool**: the target project needs no `require LeanArchitect`, no `import Architect`, and no `@[blueprint]` attributes in its source files. The extraction runs against compiled .olean files after the fact — the Lean source stays completely clean.

## Motivation

This is intended for **automatically generated repositories** — projects where Lean scaffolding is produced by an orchestration tool (e.g., [FormalFrontier](https://github.com/kim-em/FormalFrontier), which systematically formalizes textbooks into Lean 4). In these projects, every declaration should be in the blueprint, and requiring `@[blueprint]` on each one adds noise that confuses the automated agents working on the files. With `--all`, the scaffolding generator does not need to emit any LeanArchitect-specific annotations, and tools like automated theorem provers (which load the same Lean files) are not exposed to LeanArchitect imports.

## Implementation

- `--all` flag on `extract_blueprint single` (and `--all` variants of the Lake module facets: `blueprintAll`, `blueprintAllJson`)
- Filtering uses Lean canonical `allowCompletion` predicate (same as IDE completion / `exact?`) plus a declaration-ranges check (as in doc-gen4) to exclude auto-generated declarations
- Each module constants are enumerated via `env.header.moduleData[modIdx].constNames` — only the specific module is scanned, not the full environment
- Private declarations, internal names, aux recursors, no-confusion lemmas, recursors, and matchers are all excluded
- Doc-strings are captured as statement text
- Existing `@[blueprint]`-tagged declarations take priority (not duplicated)

## Tests

New test files `ArchitectTest/BlueprintAll/Basic.lean` and `ArchitectTest/BlueprintAll/Theorems.lean` — two files with no `@[blueprint]` attributes, one importing the other. Verified:
- Without `--all`: empty output
- With `--all`: exactly the user-defined declarations, with doc-strings, no auto-generated junk
- Private declarations excluded
- Existing `@[blueprint]` tests unchanged