### PR TITLE
feat: add progress tracking commands and auto-blueprinting

### DIFF
--- a/Architect/Attribute.lean
+++ b/Architect/Attribute.lean
@@ -161,9 +161,14 @@ def elabBlueprintConfig : Syntax → CoreM Config
 def hasProof (name : Name) (cfg : Config) : CoreM Bool := do
   return cfg.hasProof.getD (cfg.proof.isSome || wasOriginallyTheorem (← getEnv) name)
 
-def mkStatementPart (_name : Name) (cfg : Config) (hasProof : Bool) : CoreM NodePart := do
+def mkStatementPart (name : Name) (cfg : Config) (hasProof : Bool) : CoreM NodePart := do
+  -- If no explicit `statement := ...` is given, fall back to the declaration's docstring,
+  -- consistent with auto-mode (`blueprint.all`).
+  let text ← match cfg.statement with
+    | some s => pure s
+    | none => pure <| (docStringExt.find? (← getEnv) name).getD "" |>.trimAscii.copy
   return {
-    text := cfg.statement.getD "",
+    text,
     uses := cfg.uses, excludes := cfg.excludes,
     usesLabels := cfg.usesLabels, excludesLabels := cfg.excludesLabels,
     latexEnv := cfg.latexEnv.getD (if hasProof then "theorem" else "definition")

--- a/Architect/Basic.lean
+++ b/Architect/Basic.lean
@@ -127,4 +127,69 @@ end ResolveConst
 /-- TODO: remove after lean4#12469 -/
 scoped instance {α} [Inhabited α] : Inhabited (Thunk α) := ⟨.mk default⟩
 
+section AutoBlueprint
+
+register_option blueprint.all : Bool := {
+  defValue := false,
+  descr := "Automatically add all declarations with docstrings to the blueprint."
+}
+
+/-- Whether a constant is eligible for auto-blueprinting:
+a "real" declaration (theorem, def, opaque, or inductive) that is not auxiliary. -/
+private def isAutoEligible (env : Environment) (name : Name) : Bool :=
+  if name.isInternalDetail then false
+  else match env.find? name with
+    | some (.thmInfo _) | some (.defnInfo _) | some (.opaqueInfo _) | some (.inductInfo _) => true
+    | _ => false
+
+/-- Create an auto-node from a constant's docstring. Returns `none` if ineligible. -/
+def mkAutoNode (env : Environment) (name : Name) : Option Node :=
+  if !isAutoEligible env name then none
+  else if (blueprintExt.find? env name).isSome then none  -- already explicitly tagged
+  else match docStringExt.find? env name with
+    | none => none  -- no docstring
+    | some doc =>
+      let isThm := wasOriginallyTheorem env name
+      let statement : NodePart := {
+        text := doc.trimAscii.copy
+        uses := #[], excludes := #[], usesLabels := #[], excludesLabels := #[]
+        latexEnv := if isThm then "theorem" else "definition"
+      }
+      let proof : Option NodePart := if isThm then some {
+        text := "", uses := #[], excludes := #[], usesLabels := #[], excludesLabels := #[]
+        latexEnv := "proof"
+      } else none
+      some { name, latexLabel := name.toString, statement, proof, notReady := false
+             discussion := none, title := none }
+
+/-- Look up a blueprint node, falling back to auto-node creation when `blueprint.all` is set. -/
+def findBlueprintNode? (env : Environment) (opts : Options) (name : Name) : Option Node :=
+  (blueprintExt.find? env name).orElse fun () =>
+    if blueprint.all.get opts then mkAutoNode env name else none
+
+/-- Check if a name is a blueprint node (explicit or auto). -/
+def isBlueprintNode (env : Environment) (opts : Options) (name : Name) : Bool :=
+  (findBlueprintNode? env opts name).isSome
+
+/-- Get all blueprint nodes from an imported module.
+Auto-nodes are NOT included for imported modules — `blueprint.all` only affects the current file. -/
+def getModuleBlueprintNodes (env : Environment) (_opts : Options) (modIdx : ModuleIdx) :
+    Array (Name × Node) :=
+  blueprintExt.getModuleEntries env modIdx
+
+/-- Get all blueprint nodes from the current file (not yet imported), including auto-nodes. -/
+def getLocalBlueprintNodes (env : Environment) (opts : Options) : Array (Name × Node) :=
+  let explicit := (blueprintExt.getEntries env).toArray
+  if !blueprint.all.get opts then explicit
+  else
+    -- Find constants in env but not in any imported module
+    let autoNodes := env.constants.fold (init := #[]) fun acc name _ =>
+      if env.getModuleIdxFor? name |>.isSome then acc  -- from an import
+      else match mkAutoNode env name with
+        | some node => acc.push (name, node)
+        | none => acc
+    explicit ++ autoNodes
+
+end AutoBlueprint
+
 end Architect

--- a/Architect/Basic.lean
+++ b/Architect/Basic.lean
@@ -171,24 +171,34 @@ def findBlueprintNode? (env : Environment) (opts : Options) (name : Name) : Opti
 def isBlueprintNode (env : Environment) (opts : Options) (name : Name) : Bool :=
   (findBlueprintNode? env opts name).isSome
 
-/-- Get all blueprint nodes from an imported module.
-Auto-nodes are NOT included for imported modules — `blueprint.all` only affects the current file. -/
+/-- Collect auto-nodes (from `blueprint.all`) for all constants in `env` satisfying `keep`. -/
+private def collectAutoNodes (env : Environment) (keep : Name → Bool) : Array (Name × Node) :=
+  env.constants.fold (init := #[]) fun acc name _ =>
+    if keep name then
+      match mkAutoNode env name with
+      | some node => acc.push (name, node)
+      | none => acc
+    else acc
+
+/-- Get all explicit (`@[blueprint]`) nodes from an imported module. -/
 def getModuleBlueprintNodes (env : Environment) (_opts : Options) (modIdx : ModuleIdx) :
     Array (Name × Node) :=
   blueprintExt.getModuleEntries env modIdx
+
+/-- Get auto-nodes (from `blueprint.all`) for an imported module. Returns `#[]` unless `blueprint.all`
+is set in `opts`. This is only used when extracting that module's own blueprint — `blueprint.all` is
+otherwise scoped to the current file, so e.g. `#blueprint_progress` does not auto-blueprint imports. -/
+def getModuleAutoBlueprintNodes (env : Environment) (opts : Options) (modIdx : ModuleIdx) :
+    Array (Name × Node) :=
+  if !blueprint.all.get opts then #[]
+  else collectAutoNodes env fun name => (env.getModuleIdxFor? name).any (·.toNat == modIdx.toNat)
 
 /-- Get all blueprint nodes from the current file (not yet imported), including auto-nodes. -/
 def getLocalBlueprintNodes (env : Environment) (opts : Options) : Array (Name × Node) :=
   let explicit := (blueprintExt.getEntries env).toArray
   if !blueprint.all.get opts then explicit
-  else
-    -- Find constants in env but not in any imported module
-    let autoNodes := env.constants.fold (init := #[]) fun acc name _ =>
-      if env.getModuleIdxFor? name |>.isSome then acc  -- from an import
-      else match mkAutoNode env name with
-        | some node => acc.push (name, node)
-        | none => acc
-    explicit ++ autoNodes
+  -- Auto-nodes: constants in `env` but not in any imported module (i.e. from the current file)
+  else explicit ++ collectAutoNodes env fun name => (env.getModuleIdxFor? name).isNone
 
 end AutoBlueprint
 

--- a/Architect/Basic.lean
+++ b/Architect/Basic.lean
@@ -134,6 +134,17 @@ register_option blueprint.all : Bool := {
   descr := "Automatically add all declarations with docstrings to the blueprint."
 }
 
+/-- The module-name prefixes considered to be "libraries" (the standard library, Mathlib, etc.)
+rather than the project being blueprinted. -/
+def libraryModulePrefixes : List Name := [`Init, `Lean, `Std, `Batteries, `Mathlib]
+
+/-- Whether `name` comes from a library module (see `libraryModulePrefixes`), as opposed to the
+project being blueprinted. Declarations from the current file return `false`. -/
+def isLibraryDecl (env : Environment) (name : Name) : Bool :=
+  match env.getModuleIdxFor? name with
+  | some idx => libraryModulePrefixes.any (·.isPrefixOf env.allImportedModuleNames[idx]!)
+  | none => false
+
 /-- Whether a constant is eligible for auto-blueprinting:
 a "real" declaration (theorem, def, opaque, or inductive) that is not auxiliary. -/
 private def isAutoEligible (env : Environment) (name : Name) : Bool :=
@@ -145,6 +156,7 @@ private def isAutoEligible (env : Environment) (name : Name) : Bool :=
 /-- Create an auto-node from a constant's docstring. Returns `none` if ineligible. -/
 def mkAutoNode (env : Environment) (name : Name) : Option Node :=
   if !isAutoEligible env name then none
+  else if isLibraryDecl env name then none  -- imports (Mathlib etc.) are never auto-blueprinted
   else if (blueprintExt.find? env name).isSome then none  -- already explicitly tagged
   else match docStringExt.find? env name with
     | none => none  -- no docstring

--- a/Architect/CollectUsed.lean
+++ b/Architect/CollectUsed.lean
@@ -17,6 +17,7 @@ namespace CollectUsed
 
 structure Context where
   env : Environment
+  opts : Options
   root : Name
 
 structure State where
@@ -30,9 +31,9 @@ partial def collect (c : Name) : M Unit := do
   let s ← get
   unless s.visited.contains c do
     modify fun s => { s with visited := s.visited.insert c }
-    let { env, root } ← read
+    let { env, opts, root } ← read
     -- When we collect constants used by `a`, we don't just want to return `{a}`.
-    if c != root && (blueprintExt.find? env c).isSome then
+    if c != root && isBlueprintNode env opts c then
       modify fun s => { s with used := s.used.push c }
     else
       -- This line is `match env.checked.get.find? c with` in Lean.CollectAxioms
@@ -54,19 +55,20 @@ Returns the irreflexive transitive set of blueprint nodes that a constant depend
 as a pair of sets (constants used by type, constants used by value).
 They are made disjoint except that possibly both contain `sorryAx`.
 -/
-def collectUsed [Monad m] [MonadEnv m] [MonadError m] (constName : Name) :
+def collectUsed [Monad m] [MonadEnv m] [MonadError m] [MonadOptions m] (constName : Name) :
     m (NameSet × NameSet) := do
   let env ← getEnv
+  let opts ← getOptions
   let mut s : CollectUsed.State := {}
 
   -- Collect constants used by statement
   let info ← getConstInfo constName
   for c in info.type.getUsedConstants do
-    (_, s) := ((CollectUsed.collect c).run { env, root := constName }).run s
+    (_, s) := ((CollectUsed.collect c).run { env, opts, root := constName }).run s
   let typeUsed := NameSet.ofArray s.used
 
   -- Collect constants used by proof
-  (_, s) := ((CollectUsed.collect constName).run { env, root := constName }).run s
+  (_, s) := ((CollectUsed.collect constName).run { env, opts, root := constName }).run s
   let valueUsed := NameSet.ofArray s.used
 
   return (typeUsed, valueUsed \ typeUsed.erase ``sorryAx)

--- a/Architect/Content.lean
+++ b/Architect/Content.lean
@@ -44,12 +44,14 @@ def getMainModuleBlueprintContents : CoreM (Array BlueprintContent) := do
   let modDocs := (getMainModuleBlueprintDoc env).toArray.map BlueprintContent.modDoc
   return (nodes ++ modDocs).qsort BlueprintContent.order
 
-/-- Get blueprint contents of an imported module. -/
+/-- Get blueprint contents of an imported module. When `blueprint.all` is set, auto-nodes for the
+module's own declarations are included (this is the path used by `lake build :blueprint`). -/
 def getBlueprintContents (module : Name) : CoreM (Array BlueprintContent) := do
   let env ← getEnv
   let opts ← getOptions
   let some modIdx := env.getModuleIdx? module | return #[]
-  let nodes ← (getModuleBlueprintNodes env opts modIdx).mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
+  let allNodes := getModuleBlueprintNodes env opts modIdx ++ getModuleAutoBlueprintNodes env opts modIdx
+  let nodes ← allNodes.mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
   let modDocs := (getModuleBlueprintDoc? env module).getD #[] |>.map BlueprintContent.modDoc
   return (nodes ++ modDocs).qsort BlueprintContent.order
 

--- a/Architect/Content.lean
+++ b/Architect/Content.lean
@@ -39,15 +39,17 @@ def BlueprintContent.order (l r : BlueprintContent) : Bool :=
 /-- Get blueprint contents of the current module. -/
 def getMainModuleBlueprintContents : CoreM (Array BlueprintContent) := do
   let env ← getEnv
-  let nodes ← (blueprintExt.getEntries env).toArray.mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
+  let opts ← getOptions
+  let nodes ← (getLocalBlueprintNodes env opts).mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
   let modDocs := (getMainModuleBlueprintDoc env).toArray.map BlueprintContent.modDoc
   return (nodes ++ modDocs).qsort BlueprintContent.order
 
 /-- Get blueprint contents of an imported module. -/
 def getBlueprintContents (module : Name) : CoreM (Array BlueprintContent) := do
   let env ← getEnv
+  let opts ← getOptions
   let some modIdx := env.getModuleIdx? module | return #[]
-  let nodes ← (blueprintExt.getModuleEntries env modIdx).mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
+  let nodes ← (getModuleBlueprintNodes env opts modIdx).mapM fun (_, node) => BlueprintContent.node <$> node.toNodeWithPos
   let modDocs := (getModuleBlueprintDoc? env module).getD #[] |>.map BlueprintContent.modDoc
   return (nodes ++ modDocs).qsort BlueprintContent.order
 

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -60,4 +60,8 @@ def progressOfImportModules (modules : Array Name) (options : Options) (localOnl
         byModule := byModule.push (mod, modStats)
     return { aggregate, byModule }
 
+/-- Computes the status of a specific blueprint node and its dependency subtree. -/
+def statusOfImportModules (modules : Array Name) (constName : Name) (options : Options) : IO StatusReport :=
+  runEnvOfImports modules options (computeStatus constName)
+
 end Architect

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -64,9 +64,9 @@ def progressOfImportModules (modules : Array Name) (options : Options) (localOnl
 def statusOfImportModules (modules : Array Name) (constName : Name) (options : Options) : IO StatusReport :=
   runEnvOfImports modules options (computeStatus constName)
 
-/-- Computes actionable blueprint nodes across modules.
+/-- Computes incomplete blueprint nodes across modules.
 If `localOnly` is true, only considers nodes defined in the given modules. -/
-def nextOfImportModules (modules : Array Name) (options : Options) (localOnly : Bool := false) : IO NextReport :=
+def incompleteOfImportModules (modules : Array Name) (options : Options) (localOnly : Bool := false) : IO IncompleteReport :=
   runEnvOfImports modules options do
     let env ← getEnv
     let mut moduleNodes : Array (Name × Array Node) := #[]
@@ -76,5 +76,18 @@ def nextOfImportModules (modules : Array Name) (options : Options) (localOnly : 
         let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
         moduleNodes := moduleNodes.push (mod, nodes)
     collectIncomplete moduleNodes
+
+/-- Computes the impact of formalizing a specific blueprint node across modules.
+If `localOnly` is true, only considers nodes defined in the given modules. -/
+def impactOfImportModules (modules : Array Name) (constName : Name) (options : Options) (localOnly : Bool := false) : IO ImpactReport :=
+  runEnvOfImports modules options do
+    let env ← getEnv
+    let mut moduleNodes : Array (Name × Array Node) := #[]
+    let targetModules := if localOnly then modules else env.allImportedModuleNames
+    for mod in targetModules do
+      if let some modIdx := env.getModuleIdx? mod then
+        let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+        moduleNodes := moduleNodes.push (mod, nodes)
+    computeImpact constName moduleNodes
 
 end Architect

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -64,4 +64,17 @@ def progressOfImportModules (modules : Array Name) (options : Options) (localOnl
 def statusOfImportModules (modules : Array Name) (constName : Name) (options : Options) : IO StatusReport :=
   runEnvOfImports modules options (computeStatus constName)
 
+/-- Computes actionable blueprint nodes across modules.
+If `localOnly` is true, only considers nodes defined in the given modules. -/
+def nextOfImportModules (modules : Array Name) (options : Options) (localOnly : Bool := false) : IO NextReport :=
+  runEnvOfImports modules options do
+    let env ← getEnv
+    let mut moduleNodes : Array (Name × Array Node) := #[]
+    let targetModules := if localOnly then modules else env.allImportedModuleNames
+    for mod in targetModules do
+      if let some modIdx := env.getModuleIdx? mod then
+        let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+        moduleNodes := moduleNodes.push (mod, nodes)
+    collectIncomplete moduleNodes
+
 end Architect

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -47,14 +47,14 @@ Otherwise, also includes nodes from all their imports. -/
 def progressOfImportModules (modules : Array Name) (options : Options) (localOnly : Bool := false) : IO ProgressReport :=
   runEnvOfImports modules options do
     let env ← getEnv
+    let opts ← getOptions
     let mut aggregate := ProgressStats.empty
     let mut byModule : Array (Name × ProgressStats) := #[]
-    -- Determine which modules to include
     let targetModules := if localOnly then modules
       else env.allImportedModuleNames
     for mod in targetModules do
       if let some modIdx := env.getModuleIdx? mod then
-        let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+        let nodes := (getModuleBlueprintNodes env opts modIdx).map (·.2)
         let modStats ← computeProgress nodes
         aggregate := aggregate.merge modStats
         byModule := byModule.push (mod, modStats)
@@ -69,11 +69,12 @@ If `localOnly` is true, only considers nodes defined in the given modules. -/
 def incompleteOfImportModules (modules : Array Name) (options : Options) (localOnly : Bool := false) : IO IncompleteReport :=
   runEnvOfImports modules options do
     let env ← getEnv
+    let opts ← getOptions
     let mut moduleNodes : Array (Name × Array Node) := #[]
     let targetModules := if localOnly then modules else env.allImportedModuleNames
     for mod in targetModules do
       if let some modIdx := env.getModuleIdx? mod then
-        let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+        let nodes := (getModuleBlueprintNodes env opts modIdx).map (·.2)
         moduleNodes := moduleNodes.push (mod, nodes)
     collectIncomplete moduleNodes
 
@@ -82,11 +83,12 @@ If `localOnly` is true, only considers nodes defined in the given modules. -/
 def impactOfImportModules (modules : Array Name) (constName : Name) (options : Options) (localOnly : Bool := false) : IO ImpactReport :=
   runEnvOfImports modules options do
     let env ← getEnv
+    let opts ← getOptions
     let mut moduleNodes : Array (Name × Array Node) := #[]
     let targetModules := if localOnly then modules else env.allImportedModuleNames
     for mod in targetModules do
       if let some modIdx := env.getModuleIdx? mod then
-        let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+        let nodes := (getModuleBlueprintNodes env opts modIdx).map (·.2)
         moduleNodes := moduleNodes.push (mod, nodes)
     computeImpact constName moduleNodes
 

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -41,4 +41,12 @@ def latexOutputOfImportModule (module : Name) (options : Options) : IO LatexOutp
 def jsonOfImportModule (module : Name) (options : Options) : IO Json :=
   runEnvOfImports #[module] options (moduleToJson module)
 
+/-- Computes blueprint progress statistics for a module. -/
+def progressOfImportModule (module : Name) (options : Options) : IO ProgressStats :=
+  runEnvOfImports #[module] options do
+    let env ← getEnv
+    let some modIdx := env.getModuleIdx? module | return { total := 0, sorryFree := 0, containsSorry := 0, notReady := 0 }
+    let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+    computeProgress nodes
+
 end Architect

--- a/Architect/Load.lean
+++ b/Architect/Load.lean
@@ -41,12 +41,23 @@ def latexOutputOfImportModule (module : Name) (options : Options) : IO LatexOutp
 def jsonOfImportModule (module : Name) (options : Options) : IO Json :=
   runEnvOfImports #[module] options (moduleToJson module)
 
-/-- Computes blueprint progress statistics for a module. -/
-def progressOfImportModule (module : Name) (options : Options) : IO ProgressStats :=
-  runEnvOfImports #[module] options do
+/-- Computes blueprint progress report across modules.
+If `localOnly` is true, only counts nodes defined in the given modules.
+Otherwise, also includes nodes from all their imports. -/
+def progressOfImportModules (modules : Array Name) (options : Options) (localOnly : Bool := false) : IO ProgressReport :=
+  runEnvOfImports modules options do
     let env ← getEnv
-    let some modIdx := env.getModuleIdx? module | return { total := 0, sorryFree := 0, containsSorry := 0, notReady := 0 }
-    let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
-    computeProgress nodes
+    let mut aggregate := ProgressStats.empty
+    let mut byModule : Array (Name × ProgressStats) := #[]
+    -- Determine which modules to include
+    let targetModules := if localOnly then modules
+      else env.allImportedModuleNames
+    for mod in targetModules do
+      if let some modIdx := env.getModuleIdx? mod then
+        let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+        let modStats ← computeProgress nodes
+        aggregate := aggregate.merge modStats
+        byModule := byModule.push (mod, modStats)
+    return { aggregate, byModule }
 
 end Architect

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -107,10 +107,62 @@ def NodePart.toLatex (part : NodePart) (allParts : Array NodePart := #[part]) (i
   out := out ++ "\\end{" ++ part.latexEnv ++ "}\n"
   return out
 
-private def isMathlibOk (name : Name) : m Bool := do
+def isMathlibOk (name : Name) : m Bool := do
   let some modIdx := (← getEnv).getModuleIdxFor? name | return false
   let module := (← getEnv).allImportedModuleNames[modIdx]!
   return [`Init, `Lean, `Std, `Batteries, `Mathlib].any fun pre => pre.isPrefixOf module
+
+/-- Whether a node is sorry-free (both statement and proof have no `sorryAx`). -/
+def Node.isLeanOk (node : Node) : m Bool := do
+  let (stmtUses, proofUses) ← node.inferUses
+  return stmtUses.leanOk && proofUses.leanOk
+
+/-- Progress statistics for blueprint nodes. -/
+structure ProgressStats where
+  total : Nat
+  sorryFree : Nat
+  containsSorry : Nat
+  notReady : Nat
+
+instance : ToString ProgressStats where
+  toString s :=
+    -- Round to nearest, then adjust the last category so percentages sum to 100
+    let round (n : Nat) : Nat :=
+      if s.total == 0 then 0 else (n * 100 + s.total / 2) / s.total
+    let p1 := round s.sorryFree
+    let p2 := round s.containsSorry
+    let p3 := if s.total == 0 then 0 else 100 - p1 - p2
+    let header := "Blueprint Progress"
+    let lines := #[
+      s!"Total:        {s.total} nodes",
+      s!"Formalized:   {s.sorryFree} ({p1}%)",
+      s!"Incomplete:   {s.containsSorry} ({p2}%)",
+      s!"Not ready:    {s.notReady} ({p3}%)"
+    ]
+    let maxWidth := lines.foldl (fun acc l => max acc l.length) header.length
+    let separator := "".pushn '─' maxWidth
+    header ++ "\n" ++ separator ++ "\n" ++ "\n".intercalate lines.toList
+
+/-- Compute progress statistics for an array of blueprint nodes.
+Categories are mutually exclusive: a node is either formalized (sorry-free),
+incomplete (contains sorry), or not ready. These three sum to `total`. -/
+def computeProgress (nodes : Array Node) : m ProgressStats := do
+  let mut sorryFree := 0
+  let mut containsSorry := 0
+  let mut notReadyCount := 0
+  for node in nodes do
+    if node.notReady then
+      notReadyCount := notReadyCount + 1
+    else if ← node.isLeanOk then
+      sorryFree := sorryFree + 1
+    else
+      containsSorry := containsSorry + 1
+  return {
+    total := nodes.size
+    sorryFree
+    containsSorry
+    notReady := notReadyCount
+  }
 
 def NodeWithPos.toLatex (node : NodeWithPos) : m Latex := do
   -- In the output, we merge the Lean nodes corresponding to the same LaTeX label.
@@ -320,6 +372,22 @@ open Elab Command in
   | _ => throwUnsupportedSyntax
 
 end ToJson
+
+section Progress
+
+/-- Shows blueprint progress statistics for the current module. -/
+syntax (name := blueprint_progress) "#blueprint_progress" : command
+
+open Elab Command in
+@[command_elab blueprint_progress] def elabBlueprintProgress : CommandElab
+  | `(command| #blueprint_progress) => do
+    let env ← getEnv
+    let nodes := (blueprintExt.getEntries env).toArray.map (·.2)
+    let stats ← liftCoreM (computeProgress nodes)
+    logInfo m!"{stats}"
+  | _ => throwUnsupportedSyntax
+
+end Progress
 
 open IO
 

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -133,11 +133,15 @@ instance : ToString ProgressStats where
     let p2 := round s.containsSorry
     let p3 := if s.total == 0 then 0 else 100 - p1 - p2
     let header := "Blueprint Progress"
+    let tw := s!"{s.total}".length
+    let pad (n : Nat) := "".pushn ' ' (tw - s!"{n}".length)
+    let ppad (p : Nat) := "".pushn ' ' (3 - s!"{p}".length)
+    let totalPad := "".pushn ' ' (tw + 1)
     let lines := #[
-      s!"Total:        {s.total} nodes",
-      s!"Formalized:   {s.sorryFree} ({p1}%)",
-      s!"Incomplete:   {s.containsSorry} ({p2}%)",
-      s!"Not ready:    {s.notReady} ({p3}%)"
+      s!"Total:        {totalPad}{s.total} nodes",
+      s!"Formalized:   {pad s.sorryFree}{s.sorryFree}/{s.total} {ppad p1}({p1}%)",
+      s!"Incomplete:   {pad s.containsSorry}{s.containsSorry}/{s.total} {ppad p2}({p2}%)",
+      s!"Not ready:    {pad s.notReady}{s.notReady}/{s.total} {ppad p3}({p3}%)"
     ]
     let maxWidth := lines.foldl (fun acc l => max acc l.length) header.length
     let separator := "".pushn '─' maxWidth
@@ -465,9 +469,8 @@ open Elab Command in
 
 end Progress
 
-section Status
-
-variable {m} [Monad m] [MonadEnv m] [MonadError m]
+section Shared
+open Lean
 
 /-- Classification of a single blueprint node's formalization status. -/
 inductive NodeStatus where
@@ -478,6 +481,73 @@ instance : ToString NodeStatus where
     | .formalized => "Formalized"
     | .incomplete => "Incomplete"
     | .notReady => "Not ready"
+
+/-- A blueprint node entry with status and dependency completion data.
+Used uniformly for blocking deps, reverse deps, unblocked nodes, and incomplete nodes. -/
+structure NodeEntry where
+  name : Name
+  status : NodeStatus
+  depDone : Nat
+  depTotal : Nat
+  module : Name
+
+/-- Compute the percentage of formalized deps, rounding to nearest. -/
+private def depPct (done total : Nat) : Nat :=
+  if total == 0 then 100 else (done * 100 + total / 2) / total
+
+/-- Column widths for aligned dep-fraction formatting. -/
+structure DepFracWidths where
+  dw : Nat  -- max width of numerator
+  tw : Nat  -- max width of denominator
+  pw : Nat  -- max width of percentage
+
+/-- Compute dep-fraction column widths from an array of `NodeEntry`. -/
+def DepFracWidths.compute (entries : Array NodeEntry) : DepFracWidths where
+  dw := entries.foldl (fun acc e => max acc s!"{e.depDone}".length) 0
+  tw := entries.foldl (fun acc e => max acc s!"{e.depTotal}".length) 0
+  pw := entries.foldl (fun acc e => max acc s!"{depPct e.depDone e.depTotal}".length) 0
+
+/-- Format a dependency fraction with aligned `/` and `%` columns. -/
+private def fmtDepFrac (done total : Nat) (w : DepFracWidths) : String :=
+  let pct := depPct done total
+  let dp := "".pushn ' ' (w.dw - s!"{done}".length)
+  let tp := "".pushn ' ' (w.tw - s!"{total}".length)
+  let pp := "".pushn ' ' (w.pw - s!"{pct}".length)
+  s!"{dp}{done}/{tp}{total}  {pp}({pct}%)"
+
+/-- Format a list of `NodeEntry` as aligned rows: `name  frac  status  module` (for CLI). -/
+private def fmtNodeEntryList (entries : Array NodeEntry) : String :=
+  let maxNameWidth := entries.foldl (fun acc e => max acc (toString e.name).length) 0
+  let statusWidth := entries.foldl (fun acc e => max acc (toString e.status).length) 0
+  let fw := DepFracWidths.compute entries
+  let lines := entries.map fun e =>
+    let nameStr := toString e.name
+    let namePad := "".pushn ' ' (maxNameWidth - nameStr.length)
+    let statusStr := toString e.status
+    let statusPad := "".pushn ' ' (statusWidth - statusStr.length)
+    s!"  {nameStr}{namePad}  {fmtDepFrac e.depDone e.depTotal fw}  {statusStr}{statusPad}  {e.module}"
+  "\n".intercalate lines.toList
+
+/-- Format a list of `NodeEntry` as aligned `MessageData` rows: `name  frac  status` (for interactive). -/
+private def fmtNodeEntryListMsg (entries : Array NodeEntry) (header : MessageData) : MessageData :=
+  let maxNameWidth := entries.foldl (fun acc e => max acc (toString e.name).length) 0
+  let fw := DepFracWidths.compute entries
+  entries.foldl (init := header) fun acc e =>
+    let namePad := "".pushn ' ' (maxNameWidth - (toString e.name).length)
+    acc ++ m!"\n  {Expr.const e.name []}{namePad}  {fmtDepFrac e.depDone e.depTotal fw}  {e.status}"
+
+/-- Look up the module a constant was defined in.
+Falls back to `env.header.mainModule` for constants defined in the current file. -/
+private def getModuleOf (env : Environment) (name : Name) : Name :=
+  match env.getModuleIdxFor? name with
+  | some idx => env.allImportedModuleNames[idx.toNat]!
+  | none => env.header.mainModule
+
+end Shared
+
+section Status
+
+variable {m} [Monad m] [MonadEnv m] [MonadError m]
 
 /-- Classify a single blueprint node as formalized, incomplete, or not ready. -/
 def classifyNode (node : Node) : m NodeStatus := do
@@ -490,7 +560,7 @@ structure StatusReport where
   name : Name
   selfStatus : NodeStatus
   depStats : ProgressStats
-  blocking : Array (Name × NodeStatus)
+  blocking : Array NodeEntry
 
 private def formatStatusReport (r : StatusReport) : String :=
   let header := s!"{r.name}\nStatus: {r.selfStatus}"
@@ -503,19 +573,18 @@ private def formatStatusReport (r : StatusReport) : String :=
     let p1 := round s.sorryFree
     let p2 := round s.containsSorry
     let p3 := if s.total == 0 then 0 else 100 - p1 - p2
+    let tw := s!"{s.total}".length
+    let pad (n : Nat) := "".pushn ' ' (tw - s!"{n}".length)
+    let ppad (p : Nat) := "".pushn ' ' (3 - s!"{p}".length)
     let depSection := s!"\n\nDependencies ({s.total} nodes):"
-      ++ s!"\n  Formalized:   {s.sorryFree} ({p1}%)"
-      ++ s!"\n  Incomplete:   {s.containsSorry} ({p2}%)"
-      ++ s!"\n  Not ready:    {s.notReady} ({p3}%)"
+      ++ s!"\n  Formalized:   {pad s.sorryFree}{s.sorryFree}/{s.total} {ppad p1}({p1}%)"
+      ++ s!"\n  Incomplete:   {pad s.containsSorry}{s.containsSorry}/{s.total} {ppad p2}({p2}%)"
+      ++ s!"\n  Not ready:    {pad s.notReady}{s.notReady}/{s.total} {ppad p3}({p3}%)"
     let blockingSection :=
       if r.blocking.isEmpty then ""
       else
-        let maxNameWidth := r.blocking.foldl (fun acc (n, _) => max acc (toString n).length) 0
-        let lines := r.blocking.map fun (name, status) =>
-          let nameStr := toString name
-          let pad := "".pushn ' ' (maxNameWidth - nameStr.length)
-          s!"  {nameStr}{pad}  {status}"
-        "\n\nBlocking:\n" ++ "\n".intercalate lines.toList
+        fmtNodeEntryList r.blocking
+        |> "\n\nBlocking ({r.blocking.size} nodes):\n".append
     header ++ depSection ++ blockingSection
 
 instance : ToString StatusReport where
@@ -535,19 +604,16 @@ instance : ToMessageData StatusReport where
       let p1 := round s.sorryFree
       let p2 := round s.containsSorry
       let p3 := if s.total == 0 then 0 else 100 - p1 - p2
+      let tw := s!"{s.total}".length
+      let pad (n : Nat) := "".pushn ' ' (tw - s!"{n}".length)
+      let ppad (p : Nat) := "".pushn ' ' (3 - s!"{p}".length)
       let depSection := m!"\n\nDependencies ({s.total} nodes):"
-        ++ m!"\n  Formalized:   {s.sorryFree} ({p1}%)"
-        ++ m!"\n  Incomplete:   {s.containsSorry} ({p2}%)"
-        ++ m!"\n  Not ready:    {s.notReady} ({p3}%)"
+        ++ m!"\n  Formalized:   {pad s.sorryFree}{s.sorryFree}/{s.total} {ppad p1}({p1}%)"
+        ++ m!"\n  Incomplete:   {pad s.containsSorry}{s.containsSorry}/{s.total} {ppad p2}({p2}%)"
+        ++ m!"\n  Not ready:    {pad s.notReady}{s.notReady}/{s.total} {ppad p3}({p3}%)"
       let blockingSection :=
         if r.blocking.isEmpty then m!""
-        else
-          let maxNameWidth := r.blocking.foldl (fun acc (n, _) => max acc (toString n).length) 0
-          let lines := r.blocking.foldl (init := m!"\n\nBlocking:") fun acc (name, status) =>
-            let nameStr := toString name
-            let pad := "".pushn ' ' (maxNameWidth - nameStr.length)
-            acc ++ m!"\n  {Expr.const name []}{pad}  {status}"
-          lines
+        else fmtNodeEntryListMsg r.blocking m!"\n\nBlocking ({r.blocking.size} nodes):"
       header ++ depSection ++ blockingSection
 
 /-- Collect explicit uses from a NodePart, resolving both name-based and label-based references. -/
@@ -563,36 +629,48 @@ private def collectExplicitUses (env : Environment) (part : NodePart) : NameSet 
   let labelNames := labelNames.filter (!excludeLabelNames.contains ·)
   names.union labelNames
 
+/-- Collect all blueprint dependencies of a node (both formalized and non-formalized). -/
+private def collectAllBlueprintDeps (name : Name) : m NameSet := do
+  let env ← getEnv
+  let some node := blueprintExt.find? env name
+    | throwError "no @[blueprint] node with name {name}"
+  let (typeUsed, valueUsed) ← collectUsed name
+  let mut allUsed := typeUsed.union valueUsed |>.erase ``sorryAx
+  allUsed := (collectExplicitUses env node.statement).foldl (·.insert ·) allUsed
+  if let some proof := node.proof then
+    allUsed := (collectExplicitUses env proof).foldl (·.insert ·) allUsed
+  allUsed := allUsed.erase name
+  return allUsed.filter fun n => (blueprintExt.find? env n).isSome
+
 /-- Compute the formalization status of a specific blueprint node and its dependency subtree. -/
 def computeStatus (name : Name) : m StatusReport := do
   let env ← getEnv
   let some node := blueprintExt.find? env name
     | throwError "no @[blueprint] node with name {name}"
   let selfStatus ← classifyNode node
-  -- Get inferred transitive blueprint dependencies
-  let (typeUsed, valueUsed) ← collectUsed name
-  let mut allUsed := typeUsed.union valueUsed |>.erase ``sorryAx
-  -- Merge explicit uses from statement and proof
-  allUsed := (collectExplicitUses env node.statement).foldl (·.insert ·) allUsed
-  if let some proof := node.proof then
-    allUsed := (collectExplicitUses env proof).foldl (·.insert ·) allUsed
-  -- Remove self-reference
-  allUsed := allUsed.erase name
-  -- Filter to only blueprint nodes
-  let depNodes := allUsed.toArray.filterMap fun n => blueprintExt.find? env n
+  -- Collect all blueprint dependencies
+  let allDeps ← collectAllBlueprintDeps name
+  let depNodes := allDeps.toArray.filterMap fun n => blueprintExt.find? env n
   let depStats ← computeProgress depNodes
   -- Collect blocking (non-formalized) dependencies
-  let mut blocking : Array (Name × NodeStatus) := #[]
+  let mut blocking : Array NodeEntry := #[]
   for node in depNodes do
     let status ← classifyNode node
     unless status matches .formalized do
-      blocking := blocking.push (node.name, status)
+      let bDeps := (← collectAllBlueprintDeps node.name).toArray.filterMap fun n =>
+        blueprintExt.find? env n
+      let bStats ← computeProgress bDeps
+      blocking := blocking.push {
+        name := node.name, status
+        depDone := bStats.sorryFree, depTotal := bStats.total
+        module := getModuleOf env node.name
+      }
   -- Sort blocking: notReady first, then incomplete, alphabetical within each
-  let sortedBlocking := blocking.qsort fun (n1, s1) (n2, s2) =>
-    match s1, s2 with
+  let sortedBlocking := blocking.qsort fun a b =>
+    match a.status, b.status with
     | .notReady, .incomplete => true
     | .incomplete, .notReady => false
-    | _, _ => n1.toString < n2.toString
+    | _, _ => a.name.toString < b.name.toString
   return { name, selfStatus, depStats, blocking := sortedBlocking }
 
 /-- Shows formalization status of a specific blueprint node and its dependency subtree.
@@ -616,45 +694,37 @@ section Next
 
 variable {m} [Monad m] [MonadEnv m] [MonadError m]
 
-/-- An incomplete blueprint node with its dependency completion percentage. -/
-structure IncompleteNode where
-  name : Name
-  module : Name
-  depPct : Nat  -- percentage of deps formalized (0-100)
-
 /-- Report listing all incomplete blueprint nodes. -/
-structure NextReport where
-  nodes : Array IncompleteNode
+structure IncompleteReport where
+  nodes : Array NodeEntry
 
-instance : ToString NextReport where
+instance : ToString IncompleteReport where
   toString r :=
     if r.nodes.isEmpty then "No incomplete nodes."
     else
       let maxNameWidth := r.nodes.foldl (fun acc n => max acc (toString n.name).length) 0
+      let fw := DepFracWidths.compute r.nodes
       let lines := r.nodes.map fun node =>
         let nameStr := toString node.name
         let pad := "".pushn ' ' (maxNameWidth - nameStr.length)
-        let pctStr := s!"({node.depPct}%)"
-        let pctPad := "".pushn ' ' (6 - pctStr.length)
-        s!"  {nameStr}{pad}  {pctPad}{pctStr}  {node.module}"
+        s!"  {nameStr}{pad}  {fmtDepFrac node.depDone node.depTotal fw}  {node.module}"
       s!"Incomplete ({r.nodes.size} nodes):\n" ++ "\n".intercalate lines.toList
 
 open Lean in
-instance : ToMessageData NextReport where
+instance : ToMessageData IncompleteReport where
   toMessageData r :=
     if r.nodes.isEmpty then m!"No incomplete nodes."
     else
       let maxNameWidth := r.nodes.foldl (fun acc n => max acc (toString n.name).length) 0
+      let fw := DepFracWidths.compute r.nodes
       r.nodes.foldl (init := m!"Incomplete ({r.nodes.size} nodes):") fun acc node =>
         let pad := "".pushn ' ' (maxNameWidth - (toString node.name).length)
-        let pctStr := s!"({node.depPct}%)"
-        let pctPad := "".pushn ' ' (6 - pctStr.length)
-        acc ++ m!"\n  {Expr.const node.name []}{pad}  {pctPad}{pctStr}  {node.module}"
+        acc ++ m!"\n  {Expr.const node.name []}{pad}  {fmtDepFrac node.depDone node.depTotal fw}"
 
-/-- Collect all incomplete blueprint nodes with their dependency completion percentage. -/
-def collectIncomplete (moduleNodes : Array (Name × Array Node)) : m NextReport := do
+/-- Collect all incomplete blueprint nodes with their dependency completion fraction. -/
+def collectIncomplete (moduleNodes : Array (Name × Array Node)) : m IncompleteReport := do
   let env ← getEnv
-  let mut result : Array IncompleteNode := #[]
+  let mut result : Array NodeEntry := #[]
   for (mod, nodes) in moduleNodes do
     for node in nodes do
       if node.notReady then continue
@@ -662,21 +732,23 @@ def collectIncomplete (moduleNodes : Array (Name × Array Node)) : m NextReport 
       let status ← classifyNode node
       if status matches .formalized then continue
       let report ← computeStatus node.name
-      let depPct := if report.depStats.total == 0 then 100
-        else (report.depStats.sorryFree * 100 + report.depStats.total / 2) / report.depStats.total
-      result := result.push { name := node.name, module := mod, depPct }
+      let depDone := report.depStats.sorryFree
+      let depTotal := report.depStats.total
+      result := result.push { name := node.name, status, module := mod, depDone, depTotal }
   -- Sort by percentage descending (most ready first), then by name
   let sortedNodes := result.qsort fun a b =>
-    if a.depPct != b.depPct then a.depPct > b.depPct
+    let aPct := depPct a.depDone a.depTotal
+    let bPct := depPct b.depDone b.depTotal
+    if aPct != bPct then aPct > bPct
     else a.name.toString < b.name.toString
   return { nodes := sortedNodes }
 
-/-- Shows actionable blueprint nodes: incomplete nodes whose all dependencies are formalized.
-- `#blueprint_next` shows actionable nodes across all modules.
-- `#blueprint_next local` shows actionable nodes in the current module only. -/
-declare_syntax_cat blueprintNextOpt
-syntax &"local" : blueprintNextOpt
-syntax (name := blueprint_next) "#blueprint_next" (ppSpace blueprintNextOpt)* : command
+/-- Shows incomplete blueprint nodes sorted by dependency completion.
+- `#blueprint_incomplete` shows incomplete nodes across all modules.
+- `#blueprint_incomplete local` shows incomplete nodes in the current module only. -/
+declare_syntax_cat blueprintIncompleteOpt
+syntax &"local" : blueprintIncompleteOpt
+syntax (name := blueprint_incomplete) "#blueprint_incomplete" (ppSpace blueprintIncompleteOpt)* : command
 
 open Elab Command in
 private def collectAllModuleNodes : CommandElabM (Array (Name × Array Node)) := do
@@ -698,8 +770,8 @@ private def collectLocalModuleNodes : CommandElabM (Array (Name × Array Node)) 
   return #[(modName, nodes)]
 
 open Elab Command in
-@[command_elab blueprint_next] def elabBlueprintNext : CommandElab
-  | `(command| #blueprint_next $[$opts:blueprintNextOpt]*) => do
+@[command_elab blueprint_incomplete] def elabBlueprintIncomplete : CommandElab
+  | `(command| #blueprint_incomplete $[$opts:blueprintIncompleteOpt]*) => do
     let optStrs := opts.map (·.raw.getSubstring?.get!.toString.trimAscii.toString)
     let isLocal := optStrs.contains "local"
     let moduleNodes ← if isLocal then collectLocalModuleNodes else collectAllModuleNodes
@@ -708,6 +780,109 @@ open Elab Command in
   | _ => throwUnsupportedSyntax
 
 end Next
+
+section Impact
+
+variable {m} [Monad m] [MonadEnv m] [MonadError m]
+
+/-- Impact report: reverse dependencies and nodes that would be unblocked. -/
+structure ImpactReport where
+  name : Name
+  selfStatus : NodeStatus
+  reverseDeps : Array NodeEntry
+  wouldUnblock : Array NodeEntry
+
+private def formatImpactReport (r : ImpactReport) : String :=
+  let header := s!"{r.name}\nStatus: {r.selfStatus}"
+  let revSection :=
+    if r.reverseDeps.isEmpty then "\n\nNo nodes depend on this."
+    else
+      fmtNodeEntryList r.reverseDeps
+      |> "\n\nDepended on by ({r.reverseDeps.size} nodes):\n".append
+  let unblockSection :=
+    if r.wouldUnblock.isEmpty then ""
+    else
+      fmtNodeEntryList r.wouldUnblock
+      |> "\n\nWould unblock ({r.wouldUnblock.size} nodes):\n".append
+  header ++ revSection ++ unblockSection
+
+instance : ToString ImpactReport where
+  toString := formatImpactReport
+
+open Lean in
+instance : ToMessageData ImpactReport where
+  toMessageData r :=
+    let header := m!"{Expr.const r.name []}\nStatus: {r.selfStatus}"
+    let revSection :=
+      if r.reverseDeps.isEmpty then m!"\n\nNo nodes depend on this."
+      else
+        fmtNodeEntryListMsg r.reverseDeps
+          m!"\n\nDepended on by ({r.reverseDeps.size} nodes):"
+    let unblockSection :=
+      if r.wouldUnblock.isEmpty then m!""
+      else
+        fmtNodeEntryListMsg r.wouldUnblock
+          m!"\n\nWould unblock ({r.wouldUnblock.size} nodes):"
+    header ++ revSection ++ unblockSection
+
+/-- Compute the impact of formalizing a specific blueprint node: which nodes depend on it
+and which would become actionable. -/
+def computeImpact (targetName : Name) (moduleNodes : Array (Name × Array Node)) : m ImpactReport := do
+  let env ← getEnv
+  let some targetNode := blueprintExt.find? env targetName
+    | throwError "no @[blueprint] node with name {targetName}"
+  let selfStatus ← classifyNode targetNode
+  let mut reverseDeps : Array NodeEntry := #[]
+  let mut wouldUnblock : Array NodeEntry := #[]
+  for (mod, nodes) in moduleNodes do
+    for node in nodes do
+      if node.name == targetName then continue
+      unless env.contains node.name do continue
+      -- Check if targetName is among ALL blueprint dependencies (not just blocking)
+      let deps ← collectAllBlueprintDeps node.name
+      unless deps.contains targetName do continue
+      let status ← classifyNode node
+      let report ← computeStatus node.name
+      let depDone := report.depStats.sorryFree
+      let depTotal := report.depStats.total
+      reverseDeps := reverseDeps.push { name := node.name, status, depDone, depTotal, module := mod }
+      -- Would unblock: incomplete node whose only blocking dep is the target
+      if status matches .incomplete then
+        if report.blocking.size == 1 && report.blocking.back?.any (·.name == targetName) then
+          wouldUnblock := wouldUnblock.push { name := node.name, status, depDone, depTotal, module := mod }
+  -- Sort reverse deps: notReady first, then incomplete, alphabetical within each
+  let sortedRevDeps := reverseDeps.qsort fun a b =>
+    match a.status, b.status with
+    | .notReady, NodeStatus.incomplete => true
+    | NodeStatus.incomplete, .notReady => false
+    | _, _ => a.name.toString < b.name.toString
+  -- Sort would-unblock alphabetically
+  let sortedUnblock := wouldUnblock.qsort fun a b => a.name.toString < b.name.toString
+  return { name := targetName, selfStatus, reverseDeps := sortedRevDeps, wouldUnblock := sortedUnblock }
+
+/-- Shows the impact of formalizing a specific blueprint node: which nodes depend on it
+and which would become actionable.
+- `#blueprint_impact name` searches all imported modules.
+- `#blueprint_impact name local` searches only the current module. -/
+declare_syntax_cat blueprintImpactOpt
+syntax &"local" : blueprintImpactOpt
+syntax (name := blueprint_impact) "#blueprint_impact" ppSpace ident (ppSpace blueprintImpactOpt)* : command
+
+open Elab Command in
+@[command_elab blueprint_impact] def elabBlueprintImpact : CommandElab
+  | `(command| #blueprint_impact $id $[$opts:blueprintImpactOpt]*) => do
+    let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
+    let env ← getEnv
+    unless (blueprintExt.find? env name).isSome do
+      throwError "'{name}' is not a @[blueprint] node"
+    let optStrs := opts.map (·.raw.getSubstring?.get!.toString.trimAscii.toString)
+    let isLocal := optStrs.contains "local"
+    let moduleNodes ← if isLocal then collectLocalModuleNodes else collectAllModuleNodes
+    let report ← liftCoreM (computeImpact name moduleNodes)
+    logInfo m!"{report}"
+  | _ => throwUnsupportedSyntax
+
+end Impact
 
 open IO
 

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -143,6 +143,45 @@ instance : ToString ProgressStats where
     let separator := "".pushn '─' maxWidth
     header ++ "\n" ++ separator ++ "\n" ++ "\n".intercalate lines.toList
 
+/-- Progress report with aggregate stats and optional per-module breakdown. -/
+structure ProgressReport where
+  aggregate : ProgressStats
+  byModule : Array (Name × ProgressStats)
+  showByModule : Bool := true
+
+instance : ToString ProgressReport where
+  toString r :=
+    let agg := toString r.aggregate
+    if !r.showByModule || r.byModule.isEmpty then
+      agg
+    else
+      -- Only show modules that have blueprint nodes
+      let modules := r.byModule.filter (·.2.total > 0)
+      if modules.isEmpty then agg
+      else
+        -- Align columns: find max width of module name and fraction
+        let maxNameWidth := modules.foldl (fun acc (mod, _) => max acc (toString mod).length) 0
+        let maxFracWidth := modules.foldl (fun acc (_, s) =>
+          max acc s!"{s.sorryFree}/{s.total}".length) 0
+        let moduleLines := modules.map fun (mod, s) =>
+          let name := toString mod
+          let frac := s!"{s.sorryFree}/{s.total}"
+          let namePad := "".pushn ' ' (maxNameWidth - name.length)
+          let fracPad := "".pushn ' ' (maxFracWidth - frac.length)
+          let pct := if s.total == 0 then "0" else toString ((s.sorryFree * 100 + s.total / 2) / s.total)
+          s!"  {name}{namePad}  {fracPad}{frac}  ({pct}%)"
+        let allLines := #[agg, "", "By module:"] ++ moduleLines
+        "\n".intercalate allLines.toList
+
+def ProgressStats.merge (a b : ProgressStats) : ProgressStats :=
+  { total := a.total + b.total
+    sorryFree := a.sorryFree + b.sorryFree
+    containsSorry := a.containsSorry + b.containsSorry
+    notReady := a.notReady + b.notReady }
+
+def ProgressStats.empty : ProgressStats :=
+  { total := 0, sorryFree := 0, containsSorry := 0, notReady := 0 }
+
 /-- Compute progress statistics for an array of blueprint nodes.
 Categories are mutually exclusive: a node is either formalized (sorry-free),
 incomplete (contains sorry), or not ready. These three sum to `total`. -/
@@ -375,16 +414,53 @@ end ToJson
 
 section Progress
 
-/-- Shows blueprint progress statistics for the current module. -/
-syntax (name := blueprint_progress) "#blueprint_progress" : command
+/-- Shows blueprint progress statistics.
+- `#blueprint_progress` shows project-wide statistics with per-module breakdown.
+- `#blueprint_progress nobreakdown` shows project-wide statistics without breakdown.
+- `#blueprint_progress local` shows current module statistics with per-module breakdown.
+- `#blueprint_progress local nobreakdown` shows current module statistics without breakdown. -/
+declare_syntax_cat blueprintProgressOpt
+syntax &"local" : blueprintProgressOpt
+syntax "nobreakdown" : blueprintProgressOpt
+syntax (name := blueprint_progress) "#blueprint_progress" (ppSpace blueprintProgressOpt)* : command
+
+open Elab Command in
+private def collectAllProgress : CommandElabM (ProgressStats × Array (Name × ProgressStats)) := do
+  let env ← getEnv
+  let mut aggregate := ProgressStats.empty
+  let mut byModule : Array (Name × ProgressStats) := #[]
+  for mod in env.allImportedModuleNames do
+    if let some modIdx := env.getModuleIdx? mod then
+      let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+      let modStats ← liftCoreM (computeProgress nodes)
+      aggregate := aggregate.merge modStats
+      byModule := byModule.push (mod, modStats)
+  let currentNodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let currentStats ← liftCoreM (computeProgress currentNodes)
+  aggregate := aggregate.merge currentStats
+  byModule := byModule.push (← liftCoreM getMainModule, currentStats)
+  return (aggregate, byModule)
+
+open Elab Command in
+private def collectLocalProgress : CommandElabM (ProgressStats × Array (Name × ProgressStats)) := do
+  let env ← getEnv
+  let nodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let stats ← liftCoreM (computeProgress nodes)
+  let modName ← liftCoreM getMainModule
+  return (stats, #[(modName, stats)])
 
 open Elab Command in
 @[command_elab blueprint_progress] def elabBlueprintProgress : CommandElab
-  | `(command| #blueprint_progress) => do
-    let env ← getEnv
-    let nodes := (blueprintExt.getEntries env).toArray.map (·.2)
-    let stats ← liftCoreM (computeProgress nodes)
-    logInfo m!"{stats}"
+  | `(command| #blueprint_progress $[$opts:blueprintProgressOpt]*) => do
+    let optStrs := opts.map (·.raw.getSubstring?.get!.toString.trimAscii.toString)
+    let isLocal := optStrs.contains "local"
+    let noBreakdown := optStrs.contains "nobreakdown"
+    let (aggregate, byModule) ← if isLocal then collectLocalProgress else collectAllProgress
+    if noBreakdown then
+      logInfo m!"{aggregate}"
+    else
+      let report : ProgressReport := { aggregate, byModule }
+      logInfo m!"{report}"
   | _ => throwUnsupportedSyntax
 
 end Progress

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -612,6 +612,103 @@ open Elab Command in
 
 end Status
 
+section Next
+
+variable {m} [Monad m] [MonadEnv m] [MonadError m]
+
+/-- An incomplete blueprint node with its dependency completion percentage. -/
+structure IncompleteNode where
+  name : Name
+  module : Name
+  depPct : Nat  -- percentage of deps formalized (0-100)
+
+/-- Report listing all incomplete blueprint nodes. -/
+structure NextReport where
+  nodes : Array IncompleteNode
+
+instance : ToString NextReport where
+  toString r :=
+    if r.nodes.isEmpty then "No incomplete nodes."
+    else
+      let maxNameWidth := r.nodes.foldl (fun acc n => max acc (toString n.name).length) 0
+      let lines := r.nodes.map fun node =>
+        let nameStr := toString node.name
+        let pad := "".pushn ' ' (maxNameWidth - nameStr.length)
+        let pctStr := s!"({node.depPct}%)"
+        let pctPad := "".pushn ' ' (6 - pctStr.length)
+        s!"  {nameStr}{pad}  {pctPad}{pctStr}  {node.module}"
+      s!"Incomplete ({r.nodes.size} nodes):\n" ++ "\n".intercalate lines.toList
+
+open Lean in
+instance : ToMessageData NextReport where
+  toMessageData r :=
+    if r.nodes.isEmpty then m!"No incomplete nodes."
+    else
+      let maxNameWidth := r.nodes.foldl (fun acc n => max acc (toString n.name).length) 0
+      r.nodes.foldl (init := m!"Incomplete ({r.nodes.size} nodes):") fun acc node =>
+        let pad := "".pushn ' ' (maxNameWidth - (toString node.name).length)
+        let pctStr := s!"({node.depPct}%)"
+        let pctPad := "".pushn ' ' (6 - pctStr.length)
+        acc ++ m!"\n  {Expr.const node.name []}{pad}  {pctPad}{pctStr}  {node.module}"
+
+/-- Collect all incomplete blueprint nodes with their dependency completion percentage. -/
+def collectIncomplete (moduleNodes : Array (Name × Array Node)) : m NextReport := do
+  let env ← getEnv
+  let mut result : Array IncompleteNode := #[]
+  for (mod, nodes) in moduleNodes do
+    for node in nodes do
+      if node.notReady then continue
+      unless env.contains node.name do continue
+      let status ← classifyNode node
+      if status matches .formalized then continue
+      let report ← computeStatus node.name
+      let depPct := if report.depStats.total == 0 then 100
+        else (report.depStats.sorryFree * 100 + report.depStats.total / 2) / report.depStats.total
+      result := result.push { name := node.name, module := mod, depPct }
+  -- Sort by percentage descending (most ready first), then by name
+  let sortedNodes := result.qsort fun a b =>
+    if a.depPct != b.depPct then a.depPct > b.depPct
+    else a.name.toString < b.name.toString
+  return { nodes := sortedNodes }
+
+/-- Shows actionable blueprint nodes: incomplete nodes whose all dependencies are formalized.
+- `#blueprint_next` shows actionable nodes across all modules.
+- `#blueprint_next local` shows actionable nodes in the current module only. -/
+declare_syntax_cat blueprintNextOpt
+syntax &"local" : blueprintNextOpt
+syntax (name := blueprint_next) "#blueprint_next" (ppSpace blueprintNextOpt)* : command
+
+open Elab Command in
+private def collectAllModuleNodes : CommandElabM (Array (Name × Array Node)) := do
+  let env ← getEnv
+  let mut result : Array (Name × Array Node) := #[]
+  for mod in env.allImportedModuleNames do
+    if let some modIdx := env.getModuleIdx? mod then
+      let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+      result := result.push (mod, nodes)
+  let currentNodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  result := result.push (← liftCoreM getMainModule, currentNodes)
+  return result
+
+open Elab Command in
+private def collectLocalModuleNodes : CommandElabM (Array (Name × Array Node)) := do
+  let env ← getEnv
+  let nodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let modName ← liftCoreM getMainModule
+  return #[(modName, nodes)]
+
+open Elab Command in
+@[command_elab blueprint_next] def elabBlueprintNext : CommandElab
+  | `(command| #blueprint_next $[$opts:blueprintNextOpt]*) => do
+    let optStrs := opts.map (·.raw.getSubstring?.get!.toString.trimAscii.toString)
+    let isLocal := optStrs.contains "local"
+    let moduleNodes ← if isLocal then collectLocalModuleNodes else collectAllModuleNodes
+    let report ← liftCoreM (collectIncomplete moduleNodes)
+    logInfo m!"{report}"
+  | _ => throwUnsupportedSyntax
+
+end Next
+
 open IO
 
 def moduleToRelPath (module : Name) (ext : String) : System.FilePath :=

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -109,9 +109,7 @@ def NodePart.toLatex (part : NodePart) (allParts : Array NodePart := #[part]) (i
   return out
 
 def isMathlibOk (name : Name) : m Bool := do
-  let some modIdx := (← getEnv).getModuleIdxFor? name | return false
-  let module := (← getEnv).allImportedModuleNames[modIdx]!
-  return [`Init, `Lean, `Std, `Batteries, `Mathlib].any fun pre => pre.isPrefixOf module
+  return isLibraryDecl (← getEnv) name
 
 /-- Whether a node is sorry-free (both statement and proof have no `sorryAx`). -/
 def Node.isLeanOk (node : Node) : m Bool := do
@@ -212,7 +210,10 @@ def NodeWithPos.toLatex (node : NodeWithPos) : m Latex := do
   -- In the output, we merge the Lean nodes corresponding to the same LaTeX label.
   let env ← getEnv
   let opts ← getOptions
-  let allLeanNames := getLeanNamesOfLatexLabel env node.latexLabel
+  -- Auto-nodes (from `blueprint.all`) are materialized during extraction and don't register a
+  -- `latexLabel → name` mapping the way `@[blueprint]` does, so fall back to this node's own name.
+  let labelNames := getLeanNamesOfLatexLabel env node.latexLabel
+  let allLeanNames := if labelNames.isEmpty then #[node.name] else labelNames
   let allNodes := allLeanNames.filterMap fun name => findBlueprintNode? env opts name
 
   let mut addLatex := ""

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -516,7 +516,7 @@ def DepFracWidths.compute (entries : Array NodeEntry) : DepFracWidths where
   pw := entries.foldl (fun acc e => max acc s!"{depPct e.depDone e.depTotal}".length) 0
 
 /-- Format a dependency fraction with aligned `/` and `%` columns. -/
-private def fmtDepFrac (done total : Nat) (w : DepFracWidths) : String :=
+def fmtDepFrac (done total : Nat) (w : DepFracWidths) : String :=
   let pct := depPct done total
   let dp := "".pushn ' ' (w.dw - s!"{done}".length)
   let tp := "".pushn ' ' (w.tw - s!"{total}".length)
@@ -537,7 +537,7 @@ private def fmtNodeEntryList (entries : Array NodeEntry) : String :=
   "\n".intercalate lines.toList
 
 /-- Format a list of `NodeEntry` as aligned `MessageData` rows: `name  frac  status` (for interactive). -/
-private def fmtNodeEntryListMsg (entries : Array NodeEntry) (header : MessageData) : MessageData :=
+def fmtNodeEntryListMsg (entries : Array NodeEntry) (header : MessageData) : MessageData :=
   let maxNameWidth := entries.foldl (fun acc e => max acc (toString e.name).length) 0
   let fw := DepFracWidths.compute entries
   entries.foldl (init := header) fun acc e =>
@@ -570,7 +570,7 @@ structure StatusReport where
   depStats : ProgressStats
   blocking : Array NodeEntry
 
-private def formatStatusReport (r : StatusReport) : String :=
+def formatStatusReport (r : StatusReport) : String :=
   let header := s!"{r.name}\nStatus: {r.selfStatus}"
   if r.depStats.total == 0 then
     header ++ "\n\nNo dependencies."
@@ -805,7 +805,7 @@ structure ImpactReport where
   reverseDeps : Array NodeEntry
   wouldUnblock : Array NodeEntry
 
-private def formatImpactReport (r : ImpactReport) : String :=
+def formatImpactReport (r : ImpactReport) : String :=
   let header := s!"{r.name}\nStatus: {r.selfStatus}"
   let revSection :=
     if r.reverseDeps.isEmpty then "\n\nNo nodes depend on this."

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -41,7 +41,7 @@ def Latex.input (file : System.FilePath) : Latex :=
   -- LaTeX interprets these as control sequences, so we replace backslashes with forward slashes.
   "\\input{" ++ "/".intercalate file.components ++ "}"
 
-variable {m} [Monad m] [MonadEnv m] [MonadError m]
+variable {m} [Monad m] [MonadEnv m] [MonadError m] [MonadOptions m]
 
 def preprocessLatex (s : String) : String :=
   s
@@ -57,9 +57,10 @@ def InferredUses.merge (inferredUsess : Array InferredUses) : InferredUses :=
 
 def NodePart.inferUses (part : NodePart) (latexLabel : String) (used : NameSet) : m InferredUses := do
   let env ← getEnv
+  let opts ← getOptions
   let uses := part.uses.foldl (·.insert ·) used |>.filter (· ∉ part.excludes)
   let mut usesLabels : Std.HashSet String := .ofArray <|
-    uses.toArray.filterMap fun c => (blueprintExt.find? env c).map (·.latexLabel)
+    uses.toArray.filterMap fun c => (findBlueprintNode? env opts c).map (·.latexLabel)
   usesLabels := usesLabels.erase latexLabel
   usesLabels := part.usesLabels.foldl (·.insert ·) usesLabels |>.filter (· ∉ part.excludesLabels)
   return { uses := usesLabels.toArray, leanOk := !uses.contains ``sorryAx }
@@ -210,8 +211,9 @@ def computeProgress (nodes : Array Node) : m ProgressStats := do
 def NodeWithPos.toLatex (node : NodeWithPos) : m Latex := do
   -- In the output, we merge the Lean nodes corresponding to the same LaTeX label.
   let env ← getEnv
+  let opts ← getOptions
   let allLeanNames := getLeanNamesOfLatexLabel env node.latexLabel
-  let allNodes := allLeanNames.filterMap fun name => blueprintExt.find? env name
+  let allNodes := allLeanNames.filterMap fun name => findBlueprintNode? env opts name
 
   let mut addLatex := ""
   addLatex := addLatex ++ "\\label{" ++ node.latexLabel ++ "}\n"
@@ -339,7 +341,9 @@ open Elab Command in
     logInfo m!"LaTeX of current module:\n{output.header ""}"
   | `(command| #show_blueprint $id:ident) => do
     let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
-    let some node := blueprintExt.find? (← getEnv) name | throwError "{name} does not have @[blueprint] attribute"
+    let env ← getEnv
+    let opts ← getOptions
+    let some node := findBlueprintNode? env opts name | throwError "{name} does not have @[blueprint] attribute"
     let art ← (← liftCoreM node.toNodeWithPos).toLatexArtifact
     logInfo m!"{art.content}"
   | `(command| #show_blueprint $label:str) => do
@@ -403,7 +407,9 @@ open Elab Command in
     logInfo m!"{json}"
   | `(command| #show_blueprint_json $id:ident) => do
     let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
-    let some node := blueprintExt.find? (← getEnv) name | throwError "{name} does not have @[blueprint] attribute"
+    let env ← getEnv
+    let opts ← getOptions
+    let some node := findBlueprintNode? env opts name | throwError "{name} does not have @[blueprint] attribute"
     let json := (← liftCoreM node.toNodeWithPos).toJson
     logInfo m!"{json}"
   | `(command| #show_blueprint_json $label:str) => do
@@ -431,15 +437,16 @@ syntax (name := blueprint_progress) "#blueprint_progress" (ppSpace blueprintProg
 open Elab Command in
 private def collectAllProgress : CommandElabM (ProgressStats × Array (Name × ProgressStats)) := do
   let env ← getEnv
+  let opts ← getOptions
   let mut aggregate := ProgressStats.empty
   let mut byModule : Array (Name × ProgressStats) := #[]
   for mod in env.allImportedModuleNames do
     if let some modIdx := env.getModuleIdx? mod then
-      let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+      let nodes := (getModuleBlueprintNodes env opts modIdx).map (·.2)
       let modStats ← liftCoreM (computeProgress nodes)
       aggregate := aggregate.merge modStats
       byModule := byModule.push (mod, modStats)
-  let currentNodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let currentNodes := (getLocalBlueprintNodes env opts).map (·.2)
   let currentStats ← liftCoreM (computeProgress currentNodes)
   aggregate := aggregate.merge currentStats
   byModule := byModule.push (← liftCoreM getMainModule, currentStats)
@@ -448,7 +455,8 @@ private def collectAllProgress : CommandElabM (ProgressStats × Array (Name × P
 open Elab Command in
 private def collectLocalProgress : CommandElabM (ProgressStats × Array (Name × ProgressStats)) := do
   let env ← getEnv
-  let nodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let opts ← getOptions
+  let nodes := (getLocalBlueprintNodes env opts).map (·.2)
   let stats ← liftCoreM (computeProgress nodes)
   let modName ← liftCoreM getMainModule
   return (stats, #[(modName, stats)])
@@ -547,7 +555,7 @@ end Shared
 
 section Status
 
-variable {m} [Monad m] [MonadEnv m] [MonadError m]
+variable {m} [Monad m] [MonadEnv m] [MonadError m] [MonadOptions m]
 
 /-- Classify a single blueprint node as formalized, incomplete, or not ready. -/
 def classifyNode (node : Node) : m NodeStatus := do
@@ -632,7 +640,8 @@ private def collectExplicitUses (env : Environment) (part : NodePart) : NameSet 
 /-- Collect all blueprint dependencies of a node (both formalized and non-formalized). -/
 private def collectAllBlueprintDeps (name : Name) : m NameSet := do
   let env ← getEnv
-  let some node := blueprintExt.find? env name
+  let opts ← getOptions
+  let some node := findBlueprintNode? env opts name
     | throwError "no @[blueprint] node with name {name}"
   let (typeUsed, valueUsed) ← collectUsed name
   let mut allUsed := typeUsed.union valueUsed |>.erase ``sorryAx
@@ -640,17 +649,18 @@ private def collectAllBlueprintDeps (name : Name) : m NameSet := do
   if let some proof := node.proof then
     allUsed := (collectExplicitUses env proof).foldl (·.insert ·) allUsed
   allUsed := allUsed.erase name
-  return allUsed.filter fun n => (blueprintExt.find? env n).isSome
+  return allUsed.filter fun n => isBlueprintNode env opts n
 
 /-- Compute the formalization status of a specific blueprint node and its dependency subtree. -/
 def computeStatus (name : Name) : m StatusReport := do
   let env ← getEnv
-  let some node := blueprintExt.find? env name
+  let opts ← getOptions
+  let some node := findBlueprintNode? env opts name
     | throwError "no @[blueprint] node with name {name}"
   let selfStatus ← classifyNode node
   -- Collect all blueprint dependencies
   let allDeps ← collectAllBlueprintDeps name
-  let depNodes := allDeps.toArray.filterMap fun n => blueprintExt.find? env n
+  let depNodes := allDeps.toArray.filterMap fun n => findBlueprintNode? env opts n
   let depStats ← computeProgress depNodes
   -- Collect blocking (non-formalized) dependencies
   let mut blocking : Array NodeEntry := #[]
@@ -658,7 +668,7 @@ def computeStatus (name : Name) : m StatusReport := do
     let status ← classifyNode node
     unless status matches .formalized do
       let bDeps := (← collectAllBlueprintDeps node.name).toArray.filterMap fun n =>
-        blueprintExt.find? env n
+        findBlueprintNode? env opts n
       let bStats ← computeProgress bDeps
       blocking := blocking.push {
         name := node.name, status
@@ -682,7 +692,8 @@ open Elab Command in
   | `(command| #blueprint_status $id) => do
     let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
     let env ← getEnv
-    unless (blueprintExt.find? env name).isSome do
+    let opts ← getOptions
+    unless isBlueprintNode env opts name do
       throwError "'{name}' is not a @[blueprint] node"
     let report ← liftCoreM (computeStatus name)
     logInfo m!"{report}"
@@ -692,7 +703,7 @@ end Status
 
 section Next
 
-variable {m} [Monad m] [MonadEnv m] [MonadError m]
+variable {m} [Monad m] [MonadEnv m] [MonadError m] [MonadOptions m]
 
 /-- Report listing all incomplete blueprint nodes. -/
 structure IncompleteReport where
@@ -753,19 +764,21 @@ syntax (name := blueprint_incomplete) "#blueprint_incomplete" (ppSpace blueprint
 open Elab Command in
 private def collectAllModuleNodes : CommandElabM (Array (Name × Array Node)) := do
   let env ← getEnv
+  let opts ← getOptions
   let mut result : Array (Name × Array Node) := #[]
   for mod in env.allImportedModuleNames do
     if let some modIdx := env.getModuleIdx? mod then
-      let nodes := (blueprintExt.getModuleEntries env modIdx).map (·.2)
+      let nodes := (getModuleBlueprintNodes env opts modIdx).map (·.2)
       result := result.push (mod, nodes)
-  let currentNodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let currentNodes := (getLocalBlueprintNodes env opts).map (·.2)
   result := result.push (← liftCoreM getMainModule, currentNodes)
   return result
 
 open Elab Command in
 private def collectLocalModuleNodes : CommandElabM (Array (Name × Array Node)) := do
   let env ← getEnv
-  let nodes := (blueprintExt.getEntries env).toArray.map (·.2)
+  let opts ← getOptions
+  let nodes := (getLocalBlueprintNodes env opts).map (·.2)
   let modName ← liftCoreM getMainModule
   return #[(modName, nodes)]
 
@@ -783,7 +796,7 @@ end Next
 
 section Impact
 
-variable {m} [Monad m] [MonadEnv m] [MonadError m]
+variable {m} [Monad m] [MonadEnv m] [MonadError m] [MonadOptions m]
 
 /-- Impact report: reverse dependencies and nodes that would be unblocked. -/
 structure ImpactReport where
@@ -829,7 +842,8 @@ instance : ToMessageData ImpactReport where
 and which would become actionable. -/
 def computeImpact (targetName : Name) (moduleNodes : Array (Name × Array Node)) : m ImpactReport := do
   let env ← getEnv
-  let some targetNode := blueprintExt.find? env targetName
+  let opts ← getOptions
+  let some targetNode := findBlueprintNode? env opts targetName
     | throwError "no @[blueprint] node with name {targetName}"
   let selfStatus ← classifyNode targetNode
   let mut reverseDeps : Array NodeEntry := #[]
@@ -873,7 +887,8 @@ open Elab Command in
   | `(command| #blueprint_impact $id $[$opts:blueprintImpactOpt]*) => do
     let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
     let env ← getEnv
-    unless (blueprintExt.find? env name).isSome do
+    let leanOpts ← getOptions
+    unless isBlueprintNode env leanOpts name do
       throwError "'{name}' is not a @[blueprint] node"
     let optStrs := opts.map (·.raw.getSubstring?.get!.toString.trimAscii.toString)
     let isLocal := optStrs.contains "local"

--- a/Architect/Output.lean
+++ b/Architect/Output.lean
@@ -465,6 +465,153 @@ open Elab Command in
 
 end Progress
 
+section Status
+
+variable {m} [Monad m] [MonadEnv m] [MonadError m]
+
+/-- Classification of a single blueprint node's formalization status. -/
+inductive NodeStatus where
+  | formalized | incomplete | notReady
+
+instance : ToString NodeStatus where
+  toString
+    | .formalized => "Formalized"
+    | .incomplete => "Incomplete"
+    | .notReady => "Not ready"
+
+/-- Classify a single blueprint node as formalized, incomplete, or not ready. -/
+def classifyNode (node : Node) : m NodeStatus := do
+  if node.notReady then return .notReady
+  if ← node.isLeanOk then return .formalized
+  return .incomplete
+
+/-- Status report for a specific blueprint node and its dependency subtree. -/
+structure StatusReport where
+  name : Name
+  selfStatus : NodeStatus
+  depStats : ProgressStats
+  blocking : Array (Name × NodeStatus)
+
+private def formatStatusReport (r : StatusReport) : String :=
+  let header := s!"{r.name}\nStatus: {r.selfStatus}"
+  if r.depStats.total == 0 then
+    header ++ "\n\nNo dependencies."
+  else
+    let s := r.depStats
+    let round (n : Nat) : Nat :=
+      if s.total == 0 then 0 else (n * 100 + s.total / 2) / s.total
+    let p1 := round s.sorryFree
+    let p2 := round s.containsSorry
+    let p3 := if s.total == 0 then 0 else 100 - p1 - p2
+    let depSection := s!"\n\nDependencies ({s.total} nodes):"
+      ++ s!"\n  Formalized:   {s.sorryFree} ({p1}%)"
+      ++ s!"\n  Incomplete:   {s.containsSorry} ({p2}%)"
+      ++ s!"\n  Not ready:    {s.notReady} ({p3}%)"
+    let blockingSection :=
+      if r.blocking.isEmpty then ""
+      else
+        let maxNameWidth := r.blocking.foldl (fun acc (n, _) => max acc (toString n).length) 0
+        let lines := r.blocking.map fun (name, status) =>
+          let nameStr := toString name
+          let pad := "".pushn ' ' (maxNameWidth - nameStr.length)
+          s!"  {nameStr}{pad}  {status}"
+        "\n\nBlocking:\n" ++ "\n".intercalate lines.toList
+    header ++ depSection ++ blockingSection
+
+instance : ToString StatusReport where
+  toString := formatStatusReport
+
+open Lean in
+instance : ToMessageData StatusReport where
+  toMessageData r :=
+    let nameMsg := m!"{Expr.const r.name []}"
+    let header := m!"{nameMsg}\nStatus: {r.selfStatus}"
+    if r.depStats.total == 0 then
+      header ++ m!"\n\nNo dependencies."
+    else
+      let s := r.depStats
+      let round (n : Nat) : Nat :=
+        if s.total == 0 then 0 else (n * 100 + s.total / 2) / s.total
+      let p1 := round s.sorryFree
+      let p2 := round s.containsSorry
+      let p3 := if s.total == 0 then 0 else 100 - p1 - p2
+      let depSection := m!"\n\nDependencies ({s.total} nodes):"
+        ++ m!"\n  Formalized:   {s.sorryFree} ({p1}%)"
+        ++ m!"\n  Incomplete:   {s.containsSorry} ({p2}%)"
+        ++ m!"\n  Not ready:    {s.notReady} ({p3}%)"
+      let blockingSection :=
+        if r.blocking.isEmpty then m!""
+        else
+          let maxNameWidth := r.blocking.foldl (fun acc (n, _) => max acc (toString n).length) 0
+          let lines := r.blocking.foldl (init := m!"\n\nBlocking:") fun acc (name, status) =>
+            let nameStr := toString name
+            let pad := "".pushn ' ' (maxNameWidth - nameStr.length)
+            acc ++ m!"\n  {Expr.const name []}{pad}  {status}"
+          lines
+      header ++ depSection ++ blockingSection
+
+/-- Collect explicit uses from a NodePart, resolving both name-based and label-based references. -/
+private def collectExplicitUses (env : Environment) (part : NodePart) : NameSet :=
+  let excludeNames := part.excludes.foldl (·.insert ·) NameSet.empty
+  let names := part.uses.foldl (·.insert ·) NameSet.empty |>.filter (!excludeNames.contains ·)
+  -- Resolve usesLabels to names
+  let labelNames := part.usesLabels.foldl (init := NameSet.empty) fun acc label =>
+    (getLeanNamesOfLatexLabel env label).foldl (·.insert ·) acc
+  -- Resolve excludesLabels to names and filter
+  let excludeLabelNames := part.excludesLabels.foldl (init := NameSet.empty) fun acc label =>
+    (getLeanNamesOfLatexLabel env label).foldl (·.insert ·) acc
+  let labelNames := labelNames.filter (!excludeLabelNames.contains ·)
+  names.union labelNames
+
+/-- Compute the formalization status of a specific blueprint node and its dependency subtree. -/
+def computeStatus (name : Name) : m StatusReport := do
+  let env ← getEnv
+  let some node := blueprintExt.find? env name
+    | throwError "no @[blueprint] node with name {name}"
+  let selfStatus ← classifyNode node
+  -- Get inferred transitive blueprint dependencies
+  let (typeUsed, valueUsed) ← collectUsed name
+  let mut allUsed := typeUsed.union valueUsed |>.erase ``sorryAx
+  -- Merge explicit uses from statement and proof
+  allUsed := (collectExplicitUses env node.statement).foldl (·.insert ·) allUsed
+  if let some proof := node.proof then
+    allUsed := (collectExplicitUses env proof).foldl (·.insert ·) allUsed
+  -- Remove self-reference
+  allUsed := allUsed.erase name
+  -- Filter to only blueprint nodes
+  let depNodes := allUsed.toArray.filterMap fun n => blueprintExt.find? env n
+  let depStats ← computeProgress depNodes
+  -- Collect blocking (non-formalized) dependencies
+  let mut blocking : Array (Name × NodeStatus) := #[]
+  for node in depNodes do
+    let status ← classifyNode node
+    unless status matches .formalized do
+      blocking := blocking.push (node.name, status)
+  -- Sort blocking: notReady first, then incomplete, alphabetical within each
+  let sortedBlocking := blocking.qsort fun (n1, s1) (n2, s2) =>
+    match s1, s2 with
+    | .notReady, .incomplete => true
+    | .incomplete, .notReady => false
+    | _, _ => n1.toString < n2.toString
+  return { name, selfStatus, depStats, blocking := sortedBlocking }
+
+/-- Shows formalization status of a specific blueprint node and its dependency subtree.
+- `#blueprint_status name` shows the status of `name` and its transitive dependencies. -/
+syntax (name := blueprint_status) "#blueprint_status" ppSpace ident : command
+
+open Elab Command in
+@[command_elab blueprint_status] def elabBlueprintStatus : CommandElab
+  | `(command| #blueprint_status $id) => do
+    let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo id
+    let env ← getEnv
+    unless (blueprintExt.find? env name).isSome do
+      throwError "'{name}' is not a @[blueprint] node"
+    let report ← liftCoreM (computeStatus name)
+    logInfo m!"{report}"
+  | _ => throwUnsupportedSyntax
+
+end Status
+
 open IO
 
 def moduleToRelPath (module : Name) (ext : String) : System.FilePath :=

--- a/ArchitectTest/AutoBlueprint.lean
+++ b/ArchitectTest/AutoBlueprint.lean
@@ -1,0 +1,48 @@
+import Architect
+
+/-!
+# Auto-Blueprint Test
+
+Tests `set_option blueprint.all true` — declarations with docstrings
+are automatically included in the blueprint without `@[blueprint]`.
+-/
+
+set_option blueprint.all true
+set_option warn.sorry false
+
+namespace AutoTest
+
+/-- The base type. -/
+inductive MyType : Type where
+  | a : MyType
+  | b : MyType
+
+/-- A simple function on MyType. -/
+def flip : MyType → MyType
+  | .a => .b
+  | .b => .a
+
+/-- Flip is an involution. -/
+theorem flip_flip (x : MyType) : flip (flip x) = x := by
+  cases x <;> rfl
+
+/-- Flip applied twice is identity (sorry version). -/
+theorem flip_id (x : MyType) : flip (flip x) = x := by sorry
+
+-- No docstring — should NOT appear in blueprint
+theorem hidden_thm : True := trivial
+
+-- Explicit @[blueprint] override should still work
+/-- A custom node. -/
+@[blueprint (title := "Custom Title")]
+def custom : MyType := .a
+
+end AutoTest
+
+-- Auto-tagged declarations should appear in progress
+-- MyType, flip, flip_flip, flip_id, custom = 5 nodes
+-- hidden_thm has no docstring, so excluded
+#blueprint_progress local nobreakdown
+
+-- flip_id is incomplete (sorry), rest are formalized
+#blueprint_incomplete local

--- a/ArchitectTest/AutoBlueprint.lean
+++ b/ArchitectTest/AutoBlueprint.lean
@@ -1,4 +1,8 @@
+module
+
 import Architect
+
+public section
 
 /-!
 # Auto-Blueprint Test

--- a/ArchitectTest/Commands.lean
+++ b/ArchitectTest/Commands.lean
@@ -22,9 +22,9 @@ A dependency graph for testing.
 
 set_option warn.sorry false
 
-namespace ImpactTest
+namespace CommandsTest
 
-@[blueprint (statement := /-- The base definition everything builds on. -/)]
+/-- -/
 def base_def : Nat := 42
 
 @[blueprint (statement := /-- The core lemma used by many paths. -/)
@@ -79,9 +79,9 @@ theorem main_thm : base_def = 42 := by sorry
   (notReady := true)]
 theorem future_cor : base_def + 0 = 42 := by sorry
 
-end ImpactTest
+end CommandsTest
 
-open ImpactTest
+open CommandsTest
 
 #blueprint_impact core_lemma
 
@@ -94,3 +94,7 @@ open ImpactTest
 #blueprint_incomplete
 
 #blueprint_progress
+
+set_option blueprint.all true
+
+#show_blueprint

--- a/ArchitectTest/Commands.lean
+++ b/ArchitectTest/Commands.lean
@@ -1,4 +1,8 @@
+module
+
 import Architect
+
+public section
 
 /-!
 # Test
@@ -25,7 +29,7 @@ set_option warn.sorry false
 namespace CommandsTest
 
 /-- -/
-def base_def : Nat := 42
+@[expose] def base_def : Nat := 42
 
 @[blueprint (statement := /-- The core lemma used by many paths. -/)
   (uses := [base_def])]

--- a/ArchitectTest/ImpactTest.lean
+++ b/ArchitectTest/ImpactTest.lean
@@ -1,0 +1,99 @@
+import Architect
+
+/-!
+# Impact & Status Test
+
+A dependency graph for testing `#blueprint_status` and `#blueprint_impact`.
+
+```
+              main_thm
+             /         \
+        path_A         path_B
+        /    \            |
+ lemma_A1  lemma_A2    lemma_B1
+      |        |       /       \
+ lemma_A3  lemma_A4  lemma_B2  lemma_B3
+      \      /            |       |
+      core_lemma          util_lemma
+         |
+      base_def
+```
+-/
+
+set_option warn.sorry false
+
+namespace ImpactTest
+
+@[blueprint (statement := /-- The base definition everything builds on. -/)]
+def base_def : Nat := 42
+
+@[blueprint (statement := /-- The core lemma used by many paths. -/)
+  (uses := [base_def])]
+theorem core_lemma : base_def = 42 := rfl
+
+@[blueprint (statement := /-- A utility lemma for path B. -/)]
+theorem util_lemma : 1 + 1 = 2 := rfl
+
+@[blueprint (statement := /-- Step A3, depends on core. -/)
+  (uses := [core_lemma])]
+theorem lemma_A3 : base_def + 0 = 42 := by sorry
+
+@[blueprint (statement := /-- Step A4, depends on core. -/)
+  (uses := [core_lemma])]
+theorem lemma_A4 : base_def * 1 = 42 := by sorry
+
+@[blueprint (statement := /-- Step B2, depends on util. -/)
+  (uses := [util_lemma])]
+theorem lemma_B2 : 2 = 1 + 1 := by rfl
+
+@[blueprint (statement := /-- Step B3, depends on util. -/)
+  (uses := [util_lemma])]
+theorem lemma_B3 : 1 + 1 + 1 = 3 := by sorry
+
+@[blueprint (statement := /-- Step A1, depends on A3. -/)
+  (uses := [lemma_A3])]
+theorem lemma_A1 : base_def + 0 + 0 = 42 := by sorry
+
+@[blueprint (statement := /-- Step A2, depends on A4. -/)
+  (uses := [lemma_A4])]
+theorem lemma_A2 : base_def * 1 * 1 = 42 := by sorry
+
+@[blueprint (statement := /-- Step B1, depends on B2 and B3. -/)
+  (uses := [lemma_B2, lemma_B3])]
+theorem lemma_B1 : 1 + 1 + 1 = 3 := by sorry
+
+@[blueprint (statement := /-- Path A converges from A1 and A2. -/)
+  (uses := [lemma_A1, lemma_A2])]
+theorem path_A : base_def = 42 := by sorry
+
+@[blueprint (statement := /-- Path B goes through B1. -/)
+  (uses := [lemma_B1])]
+theorem path_B : 1 + 2 = 3 := by sorry
+
+@[blueprint (statement := /-- The main theorem, combining both paths. -/)
+  (uses := [path_A, path_B])]
+theorem main_thm : base_def = 42 := by sorry
+
+@[blueprint (statement := /-- A corollary of the main theorem. -/)
+  (uses := [main_thm])
+  (notReady := true)]
+theorem future_cor : base_def + 0 = 42 := by sorry
+
+end ImpactTest
+
+open ImpactTest in
+#blueprint_impact core_lemma
+
+open ImpactTest in
+#blueprint_impact lemma_B1
+
+open ImpactTest in
+#blueprint_status lemma_A2
+
+open ImpactTest in
+
+#blueprint_status main_thm
+
+#blueprint_incomplete
+
+#blueprint_progress

--- a/ArchitectTest/ImpactTest.lean
+++ b/ArchitectTest/ImpactTest.lean
@@ -1,9 +1,9 @@
 import Architect
 
 /-!
-# Impact & Status Test
+# Test
 
-A dependency graph for testing `#blueprint_status` and `#blueprint_impact`.
+A dependency graph for testing.
 
 ```
               main_thm
@@ -13,9 +13,9 @@ A dependency graph for testing `#blueprint_status` and `#blueprint_impact`.
  lemma_A1  lemma_A2    lemma_B1
       |        |       /       \
  lemma_A3  lemma_A4  lemma_B2  lemma_B3
-      \      /            |       |
-      core_lemma          util_lemma
-         |
+      \       /           \      / 
+      core_lemma         util_lemma
+          |
       base_def
 ```
 -/
@@ -81,16 +81,13 @@ theorem future_cor : base_def + 0 = 42 := by sorry
 
 end ImpactTest
 
-open ImpactTest in
+open ImpactTest
+
 #blueprint_impact core_lemma
 
-open ImpactTest in
 #blueprint_impact lemma_B1
 
-open ImpactTest in
 #blueprint_status lemma_A2
-
-open ImpactTest in
 
 #blueprint_status main_thm
 

--- a/Main.lean
+++ b/Main.lean
@@ -95,6 +95,28 @@ def statsCmd := `[Cli|
     ...modules : String; "The modules to compute blueprint progress for."
 ]
 
+def runStatusCmd (p : Parsed) : IO UInt32 := do
+  let modules := p.variableArgsAs! String |>.map (·.toName)
+  let name := (p.positionalArg! "name" |>.as! String).toName
+  let options : LeanOptions ← match p.flag? "options" with
+    | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
+    | none => pure (∅ : LeanOptions)
+  let report ← statusOfImportModules modules name options.toOptions
+  IO.println s!"{report}"
+  return 0
+
+def statusCmd := `[Cli|
+  status VIA runStatusCmd;
+  "Show formalization status of a specific blueprint node and its dependency subtree."
+
+  FLAGS:
+    o, options : String; "LeanOptions in JSON to pass to running the modules."
+
+  ARGS:
+    name : String; "The fully qualified Lean name of the declaration."
+    ...modules : String; "The modules to load (the declaration must be reachable from these)."
+]
+
 def blueprintCmd : Cmd := `[Cli|
   "LeanArchitect" NOOP;
   "A blueprint generator for Lean 4."
@@ -102,7 +124,8 @@ def blueprintCmd : Cmd := `[Cli|
   SUBCOMMANDS:
     singleCmd;
     indexCmd;
-    statsCmd
+    statsCmd;
+    statusCmd
 ]
 
 def main (args : List String) : IO UInt32 :=

--- a/Main.lean
+++ b/Main.lean
@@ -117,6 +117,28 @@ def statusCmd := `[Cli|
     ...modules : String; "The modules to load (the declaration must be reachable from these)."
 ]
 
+def runNextCmd (p : Parsed) : IO UInt32 := do
+  let modules := p.variableArgsAs! String |>.map (·.toName)
+  let options : LeanOptions ← match p.flag? "options" with
+    | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
+    | none => pure (∅ : LeanOptions)
+  let localOnly := p.hasFlag "local"
+  let report ← nextOfImportModules modules options.toOptions localOnly
+  IO.println s!"{report}"
+  return 0
+
+def nextCmd := `[Cli|
+  next VIA runNextCmd;
+  "Show actionable blueprint nodes: incomplete nodes whose all dependencies are formalized."
+
+  FLAGS:
+    l, "local"; "Only consider nodes defined in the given modules, excluding imports."
+    o, options : String; "LeanOptions in JSON to pass to running the modules."
+
+  ARGS:
+    ...modules : String; "The modules to search for actionable nodes."
+]
+
 def blueprintCmd : Cmd := `[Cli|
   "LeanArchitect" NOOP;
   "A blueprint generator for Lean 4."
@@ -125,7 +147,8 @@ def blueprintCmd : Cmd := `[Cli|
     singleCmd;
     indexCmd;
     statsCmd;
-    statusCmd
+    statusCmd;
+    nextCmd
 ]
 
 def main (args : List String) : IO UInt32 :=

--- a/Main.lean
+++ b/Main.lean
@@ -44,6 +44,15 @@ def runIndexCmd (p : Parsed) : IO UInt32 := do
     outputLibraryLatex baseDir library modules
   return 0
 
+def runStatsCmd (p : Parsed) : IO UInt32 := do
+  let module := p.positionalArg! "module" |>.as! String |>.toName
+  let options : LeanOptions ← match p.flag? "options" with
+    | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
+    | none => pure (∅ : LeanOptions)
+  let stats ← progressOfImportModule module options.toOptions
+  IO.println s!"{stats}"
+  return 0
+
 def singleCmd := `[Cli|
   single VIA runSingleCmd;
   "Only extract the blueprint for the module it was given, might contain broken \\input{}s unless all blueprint files are extracted."
@@ -70,13 +79,25 @@ def indexCmd := `[Cli|
     modules : Array String; "The modules in the library."
 ]
 
+def statsCmd := `[Cli|
+  stats VIA runStatsCmd;
+  "Output progress statistics for the blueprint nodes in a module."
+
+  FLAGS:
+    o, options : String; "LeanOptions in JSON to pass to running the module."
+
+  ARGS:
+    module : String; "The module to compute blueprint progress for."
+]
+
 def blueprintCmd : Cmd := `[Cli|
   "LeanArchitect" NOOP;
   "A blueprint generator for Lean 4."
 
   SUBCOMMANDS:
     singleCmd;
-    indexCmd
+    indexCmd;
+    statsCmd
 ]
 
 def main (args : List String) : IO UInt32 :=

--- a/Main.lean
+++ b/Main.lean
@@ -45,11 +45,14 @@ def runIndexCmd (p : Parsed) : IO UInt32 := do
   return 0
 
 def runStatsCmd (p : Parsed) : IO UInt32 := do
-  let module := p.positionalArg! "module" |>.as! String |>.toName
+  let modules := p.variableArgsAs! String |>.map (·.toName)
   let options : LeanOptions ← match p.flag? "options" with
     | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
     | none => pure (∅ : LeanOptions)
-  let stats ← progressOfImportModule module options.toOptions
+  let localOnly := p.hasFlag "local"
+  let noBreakdown := p.hasFlag "nobreakdown"
+  let stats ← progressOfImportModules modules options.toOptions localOnly
+  let stats := { stats with showByModule := !noBreakdown }
   IO.println s!"{stats}"
   return 0
 
@@ -81,13 +84,15 @@ def indexCmd := `[Cli|
 
 def statsCmd := `[Cli|
   stats VIA runStatsCmd;
-  "Output progress statistics for the blueprint nodes in a module."
+  "Output progress statistics for the blueprint nodes in one or more modules."
 
   FLAGS:
-    o, options : String; "LeanOptions in JSON to pass to running the module."
+    l, "local"; "Only count nodes defined in the given modules, excluding imports."
+    n, "nobreakdown"; "Hide the per-module breakdown."
+    o, options : String; "LeanOptions in JSON to pass to running the modules."
 
   ARGS:
-    module : String; "The module to compute blueprint progress for."
+    ...modules : String; "The modules to compute blueprint progress for."
 ]
 
 def blueprintCmd : Cmd := `[Cli|

--- a/Main.lean
+++ b/Main.lean
@@ -44,7 +44,7 @@ def runIndexCmd (p : Parsed) : IO UInt32 := do
     outputLibraryLatex baseDir library modules
   return 0
 
-def runStatsCmd (p : Parsed) : IO UInt32 := do
+def runProgressCmd (p : Parsed) : IO UInt32 := do
   let modules := p.variableArgsAs! String |>.map (·.toName)
   let options : LeanOptions ← match p.flag? "options" with
     | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
@@ -82,8 +82,8 @@ def indexCmd := `[Cli|
     modules : Array String; "The modules in the library."
 ]
 
-def statsCmd := `[Cli|
-  stats VIA runStatsCmd;
+def progressCmd := `[Cli|
+  progress VIA runProgressCmd;
   "Output progress statistics for the blueprint nodes in one or more modules."
 
   FLAGS:
@@ -117,26 +117,50 @@ def statusCmd := `[Cli|
     ...modules : String; "The modules to load (the declaration must be reachable from these)."
 ]
 
-def runNextCmd (p : Parsed) : IO UInt32 := do
+def runIncompleteCmd (p : Parsed) : IO UInt32 := do
   let modules := p.variableArgsAs! String |>.map (·.toName)
   let options : LeanOptions ← match p.flag? "options" with
     | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
     | none => pure (∅ : LeanOptions)
   let localOnly := p.hasFlag "local"
-  let report ← nextOfImportModules modules options.toOptions localOnly
+  let report ← incompleteOfImportModules modules options.toOptions localOnly
   IO.println s!"{report}"
   return 0
 
-def nextCmd := `[Cli|
-  next VIA runNextCmd;
-  "Show actionable blueprint nodes: incomplete nodes whose all dependencies are formalized."
+def incompleteCmd := `[Cli|
+  incomplete VIA runIncompleteCmd;
+  "Show incomplete blueprint nodes sorted by dependency completion."
 
   FLAGS:
     l, "local"; "Only consider nodes defined in the given modules, excluding imports."
     o, options : String; "LeanOptions in JSON to pass to running the modules."
 
   ARGS:
-    ...modules : String; "The modules to search for actionable nodes."
+    ...modules : String; "The modules to search for incomplete nodes."
+]
+
+def runImpactCmd (p : Parsed) : IO UInt32 := do
+  let modules := p.variableArgsAs! String |>.map (·.toName)
+  let name := (p.positionalArg! "name" |>.as! String).toName
+  let options : LeanOptions ← match p.flag? "options" with
+    | some o => IO.ofExcept (Json.parse (o.as! String) >>= fromJson?)
+    | none => pure (∅ : LeanOptions)
+  let localOnly := p.hasFlag "local"
+  let report ← impactOfImportModules modules name options.toOptions localOnly
+  IO.println s!"{report}"
+  return 0
+
+def impactCmd := `[Cli|
+  impact VIA runImpactCmd;
+  "Show which nodes depend on a given blueprint node and which would be unblocked by formalizing it."
+
+  FLAGS:
+    l, "local"; "Only consider nodes defined in the given modules, excluding imports."
+    o, options : String; "LeanOptions in JSON to pass to running the modules."
+
+  ARGS:
+    name : String; "The fully qualified Lean name of the declaration."
+    ...modules : String; "The modules to load (the declaration must be reachable from these)."
 ]
 
 def blueprintCmd : Cmd := `[Cli|
@@ -146,9 +170,10 @@ def blueprintCmd : Cmd := `[Cli|
   SUBCOMMANDS:
     singleCmd;
     indexCmd;
-    statsCmd;
+    progressCmd;
     statusCmd;
-    nextCmd
+    incompleteCmd;
+    impactCmd
 ]
 
 def main (args : List String) : IO UInt32 :=

--- a/README.md
+++ b/README.md
@@ -223,17 +223,29 @@ To view formalization progress, use the `#blueprint_progress` command in Lean:
 ```lean
 #blueprint_progress
 -- Blueprint Progress
--- ─────────────────────
--- Total:        8 nodes
--- Formalized:   3 (38%)
--- Incomplete:   4 (50%)
--- Not ready:    1 (12%)
+-- ──────────────────────
+-- Total:        10 nodes
+-- Formalized:   5 (50%)
+-- Incomplete:   4 (40%)
+-- Not ready:    1 (10%)
+--
+-- By module:
+--   MyProject.Algebra  3/8 (37%)
+--   MyProject.Topology  1/1 (100%)
+--   MyProject.Main  1/1 (100%)
 ```
 
-Or from the command line:
+The command aggregates all blueprint nodes from the current module and its imports, with a per-module breakdown. Place it in a root file that imports the full project to get project-wide statistics. Variants:
+
+- `#blueprint_progress` — project-wide with per-module breakdown.
+- `#blueprint_progress nobreakdown` — project-wide without breakdown.
+- `#blueprint_progress local` — current module only, with breakdown.
+- `#blueprint_progress local nobreakdown` — current module only, without breakdown.
+
+Or from the command line, passing one or more modules:
 
 ```sh
-lake exe extract_blueprint stats MyProject.MyModule
+lake exe extract_blueprint stats MyProject.Module1 MyProject.Module2
 ```
 
 Nodes are categorized into three mutually exclusive groups:

--- a/README.md
+++ b/README.md
@@ -216,6 +216,31 @@ so that the `\input` line above works. Here are some typical examples for doing 
           build-args: :blueprint
 ```
 
+## Progress statistics
+
+To view formalization progress, use the `#blueprint_progress` command in Lean:
+
+```lean
+#blueprint_progress
+-- Blueprint Progress
+-- ─────────────────────
+-- Total:        8 nodes
+-- Formalized:   3 (38%)
+-- Incomplete:   4 (50%)
+-- Not ready:    1 (12%)
+```
+
+Or from the command line:
+
+```sh
+lake exe extract_blueprint stats MyProject.MyModule
+```
+
+Nodes are categorized into three mutually exclusive groups:
+- **Formalized**: `sorry`-free, formalization complete.
+- **Incomplete**: contains `sorry`, work in progress.
+- **Not ready**: marked with `(notReady := true)`, not yet actionable.
+
 ## Extracting nodes in JSON
 
 To extract the blueprint nodes in machine-readable format, run:

--- a/README.md
+++ b/README.md
@@ -288,6 +288,32 @@ lake exe extract_blueprint status MyProject.add_comm MyProject.Module1
 
 The first argument is the fully qualified Lean name; the remaining arguments are the modules to load (the declaration must be reachable from these modules).
 
+## Incomplete nodes
+
+To see all incomplete nodes and how close they are to being unblocked, use `#blueprint_next`:
+
+```lean
+#blueprint_next
+-- Incomplete (4 nodes):
+--   MyProject.mul       (100%)  MyProject.Algebra
+--   MyProject.succ_add  (100%)  MyProject.Algebra
+--   MyProject.add_comm   (75%)  MyProject.Topology
+--   MyProject.mul_comm   (50%)  MyProject.Algebra
+```
+
+Each node shows the percentage of its transitive blueprint dependencies that are formalized. Nodes at **100%** are ready to work on immediately — all their dependencies are done. Nodes marked `(notReady := true)` are excluded.
+
+Variants:
+
+- `#blueprint_next` — search all modules.
+- `#blueprint_next local` — search the current module only.
+
+Or from the command line:
+
+```sh
+lake exe extract_blueprint next MyProject.Module1 MyProject.Module2
+```
+
 ## Extracting nodes in JSON
 
 To extract the blueprint nodes in machine-readable format, run:

--- a/README.md
+++ b/README.md
@@ -223,16 +223,16 @@ To view formalization progress, use the `#blueprint_progress` command in Lean:
 ```lean
 #blueprint_progress
 -- Blueprint Progress
--- ──────────────────────
--- Total:        10 nodes
--- Formalized:   5 (50%)
--- Incomplete:   4 (40%)
--- Not ready:    1 (10%)
+-- ────────────────────────
+-- Total:           10 nodes
+-- Formalized:    5/10  (50%)
+-- Incomplete:    4/10  (40%)
+-- Not ready:     1/10  (10%)
 --
 -- By module:
---   MyProject.Algebra  3/8 (37%)
---   MyProject.Topology  1/1 (100%)
---   MyProject.Main  1/1 (100%)
+--   MyProject.Algebra   3/8  (38%)
+--   MyProject.Topology  1/1  (100%)
+--   MyProject.Main      1/1  (100%)
 ```
 
 The command aggregates all blueprint nodes from the current module and its imports, with a per-module breakdown. Place it in a root file that imports the full project to get project-wide statistics. Variants:
@@ -245,7 +245,7 @@ The command aggregates all blueprint nodes from the current module and its impor
 Or from the command line, passing one or more modules:
 
 ```sh
-lake exe extract_blueprint stats MyProject.Module1 MyProject.Module2
+lake exe extract_blueprint progress MyProject.Module1 MyProject.Module2
 ```
 
 Nodes are categorized into three mutually exclusive groups:
@@ -263,13 +263,13 @@ To inspect a specific declaration and its dependency subtree, use `#blueprint_st
 -- Status: Incomplete
 --
 -- Dependencies (3 nodes):
---   Formalized:   1 (33%)
---   Incomplete:   2 (67%)
---   Not ready:    0 (0%)
+--   Formalized:   1/3  (33%)
+--   Incomplete:   2/3  (67%)
+--   Not ready:    0/3   (0%)
 --
--- Blocking:
---   MyProject.succ_add  Incomplete
---   MyProject.mul       Incomplete
+-- Blocking (2 nodes):
+--   MyProject.succ_add  1/2  (50%)  Incomplete
+--   MyProject.mul       0/1   (0%)  Incomplete
 ```
 
 This works on any `@[blueprint]`-tagged declaration — theorems, lemmas, definitions, and inductives. The output shows:
@@ -290,28 +290,63 @@ The first argument is the fully qualified Lean name; the remaining arguments are
 
 ## Incomplete nodes
 
-To see all incomplete nodes and how close they are to being unblocked, use `#blueprint_next`:
+To see all incomplete nodes and how close they are to being unblocked, use `#blueprint_incomplete`:
 
 ```lean
-#blueprint_next
+#blueprint_incomplete
 -- Incomplete (4 nodes):
---   MyProject.mul       (100%)  MyProject.Algebra
---   MyProject.succ_add  (100%)  MyProject.Algebra
---   MyProject.add_comm   (75%)  MyProject.Topology
---   MyProject.mul_comm   (50%)  MyProject.Algebra
+--   MyProject.mul       0/0 (100%)  MyProject.Algebra
+--   MyProject.succ_add  2/2 (100%)  MyProject.Algebra
+--   MyProject.add_comm  3/4  (75%)  MyProject.Topology
+--   MyProject.mul_comm  1/2  (50%)  MyProject.Algebra
 ```
 
-Each node shows the percentage of its transitive blueprint dependencies that are formalized. Nodes at **100%** are ready to work on immediately — all their dependencies are done. Nodes marked `(notReady := true)` are excluded.
+Each node shows how many of its blueprint dependencies are formalized. Nodes at **100%** are ready to work on immediately — all their dependencies are done. Nodes marked `(notReady := true)` are excluded.
 
 Variants:
 
-- `#blueprint_next` — search all modules.
-- `#blueprint_next local` — search the current module only.
+- `#blueprint_incomplete` — search all modules.
+- `#blueprint_incomplete local` — search the current module only.
 
 Or from the command line:
 
 ```sh
-lake exe extract_blueprint next MyProject.Module1 MyProject.Module2
+lake exe extract_blueprint incomplete MyProject.Module1 MyProject.Module2
+```
+
+### Impact analysis
+
+To see the reverse dependencies of a node — which nodes depend on it and which would be unblocked by formalizing it — use `#blueprint_impact`:
+
+```lean
+#blueprint_impact MyProject.succ_add
+```
+
+Example output:
+
+```
+MyProject.succ_add
+Status: Incomplete
+
+Depended on by (2 nodes):
+  MyProject.add_comm  3/4  (75%)  Incomplete  MyProject.Algebra
+  MyProject.flt       0/2   (0%)  Not ready   MyProject.Algebra
+
+Would unblock (1 node):
+  MyProject.add_comm  3/4  (75%)  Incomplete  MyProject.Algebra
+```
+
+"Would unblock" lists incomplete nodes whose *only* remaining blocking dependency is the target node. Formalizing the target would make these nodes fully actionable (100% dependency completion in `#blueprint_incomplete`).
+
+Variants:
+
+- `#blueprint_impact name` — search all modules.
+- `#blueprint_impact name local` — search the current module only.
+
+Or from the command line:
+
+```sh
+lake exe extract_blueprint impact MyProject.succ_add MyProject.Module1 MyProject.Module2
 ```
 
 ## Extracting nodes in JSON

--- a/README.md
+++ b/README.md
@@ -253,6 +253,41 @@ Nodes are categorized into three mutually exclusive groups:
 - **Incomplete**: contains `sorry`, work in progress.
 - **Not ready**: marked with `(notReady := true)`, not yet actionable.
 
+## Node status
+
+To inspect a specific declaration and its dependency subtree, use `#blueprint_status`:
+
+```lean
+#blueprint_status MyProject.add_comm
+-- MyProject.add_comm
+-- Status: Incomplete
+--
+-- Dependencies (3 nodes):
+--   Formalized:   1 (33%)
+--   Incomplete:   2 (67%)
+--   Not ready:    0 (0%)
+--
+-- Blocking:
+--   MyProject.succ_add  Incomplete
+--   MyProject.mul       Incomplete
+```
+
+This works on any `@[blueprint]`-tagged declaration — theorems, lemmas, definitions, and inductives. The output shows:
+
+- **Status**: the node's own formalization status.
+- **Dependencies**: aggregate statistics for all transitive blueprint dependencies.
+- **Blocking**: the subset of dependencies that are not yet formalized, sorted with not-ready nodes first.
+
+If the node has no blueprint dependencies, the output shows `No dependencies.` instead.
+
+Or from the command line:
+
+```sh
+lake exe extract_blueprint status MyProject.add_comm MyProject.Module1
+```
+
+The first argument is the fully qualified Lean name; the remaining arguments are the modules to load (the declaration must be reachable from these modules).
+
 ## Extracting nodes in JSON
 
 To extract the blueprint nodes in machine-readable format, run:

--- a/README.md
+++ b/README.md
@@ -216,6 +216,34 @@ so that the `\input` line above works. Here are some typical examples for doing 
           build-args: :blueprint
 ```
 
+## Auto-blueprinting
+
+By default, each declaration must be tagged with `@[blueprint]` to appear in the blueprint. To automatically include all declarations with docstrings, use:
+
+```lean
+set_option blueprint.all true
+
+/-- Natural number addition. -/
+def add (a b : Nat) : Nat := ...          -- auto-blueprinted
+
+/-- Commutativity of addition. -/
+theorem add_comm : add a b = add b a := ...  -- auto-blueprinted
+
+theorem helper : ... := ...               -- NOT included (no docstring)
+```
+
+The statement text comes from the docstring, dependencies are auto-inferred, and the LaTeX environment is determined by the declaration kind (theorem → `theorem`, def/inductive → `definition`).
+
+To override specific options for a declaration, add `@[blueprint ...]` explicitly — it takes precedence over auto-mode:
+
+```lean
+/-- Fermat's last theorem. -/
+@[blueprint (title := "Taylor-Wiles") (notReady := true)]
+theorem flt : ... := ...
+```
+
+Note: `blueprint.all` only affects the current file. Imported modules are not auto-blueprinted.
+
 ## Progress statistics
 
 To view formalization progress, use the `#blueprint_progress` command in Lean:
@@ -272,6 +300,12 @@ To inspect a specific declaration and its dependency subtree, use `#blueprint_st
 --   MyProject.mul       0/1   (0%)  Incomplete
 ```
 
+Or from the command line:
+
+```sh
+lake exe extract_blueprint status MyProject.add_comm MyProject.Module1
+```
+
 This works on any `@[blueprint]`-tagged declaration — theorems, lemmas, definitions, and inductives. The output shows:
 
 - **Status**: the node's own formalization status.
@@ -295,10 +329,10 @@ To see all incomplete nodes and how close they are to being unblocked, use `#blu
 ```lean
 #blueprint_incomplete
 -- Incomplete (4 nodes):
---   MyProject.mul       0/0 (100%)  MyProject.Algebra
---   MyProject.succ_add  2/2 (100%)  MyProject.Algebra
---   MyProject.add_comm  3/4  (75%)  MyProject.Topology
---   MyProject.mul_comm  1/2  (50%)  MyProject.Algebra
+--   MyProject.mul       0/0  (100%)
+--   MyProject.succ_add  2/2  (100%)
+--   MyProject.add_comm  3/4   (75%)
+--   MyProject.mul_comm  1/2   (50%)
 ```
 
 Each node shows how many of its blueprint dependencies are formalized. Nodes at **100%** are ready to work on immediately — all their dependencies are done. Nodes marked `(notReady := true)` are excluded.
@@ -329,11 +363,11 @@ MyProject.succ_add
 Status: Incomplete
 
 Depended on by (2 nodes):
-  MyProject.add_comm  3/4  (75%)  Incomplete  MyProject.Algebra
-  MyProject.flt       0/2   (0%)  Not ready   MyProject.Algebra
+  MyProject.add_comm  3/4  (75%)  Incomplete
+  MyProject.flt       0/2   (0%)  Not ready
 
 Would unblock (1 node):
-  MyProject.add_comm  3/4  (75%)  Incomplete  MyProject.Algebra
+  MyProject.add_comm  3/4  (75%)  Incomplete
 ```
 
 "Would unblock" lists incomplete nodes whose *only* remaining blocking dependency is the target node. Formalizing the target would make these nodes fully actionable (100% dependency completion in `#blueprint_incomplete`).

--- a/README.md
+++ b/README.md
@@ -261,6 +261,41 @@ leanOptions = [{ name = "blueprint.all", value = true }]
 
 Note: `blueprint.all` only auto-blueprints the modules it is applied to; declarations from imported libraries (e.g. Mathlib) are never auto-blueprinted.
 
+### Customizing the LaTeX environment
+
+Auto-mode picks the LaTeX environment from the kernel-level kind of the declaration: theorem-kind → `\begin{theorem}`, def/inductive/opaque → `\begin{definition}`. Lean does not preserve the surface keyword across macro expansion — for example, Mathlib's `lemma` is a macro that desugars to `theorem` before LeanArchitect sees it, so auto-mode can't tell `lemma foo` apart from `theorem foo` and renders both as `\begin{theorem}`. Two ways to control this:
+
+**Per-declaration override.** Explicit `@[blueprint ...]` takes precedence over auto-mode, so you can selectively pick a different environment:
+
+```lean
+@[blueprint (latexEnv := "lemma")]
+lemma mul_one (a : G) : a * 1 = a := …
+```
+
+**Project-side `macro_rules`.** To avoid tagging each declaration, drop a small file into your project — e.g. `MyProject/Blueprint.lean` — that redirects the surface keyword so it carries the attribute automatically. Mathlib's `lemma` syntax has a single `declModifiers` slot that already includes the attribute position, so the simplest correct shape captures the optional `docComment` separately and lets the RHS attribute land in the rewritten `theorem`'s own modifiers:
+
+```lean
+-- MyProject/Blueprint.lean
+/-
+  Route Mathlib's `lemma` keyword to `\begin{lemma}` in the published
+  blueprint. Without this, auto-mode sees only the kernel-level
+  declaration kind (theorem-kind for `lemma`) and renders both
+  `theorem foo` and `lemma foo` as `\begin{theorem}`.
+-/
+
+import Architect
+import Mathlib.Tactic.Lemma
+
+macro_rules
+  | `(command| $[$doc:docComment]? lemma $id:declId $sig:declSig $val:declVal) =>
+    `(command| $[$doc:docComment]? @[blueprint (latexEnv := "lemma")]
+        theorem $id:declId $sig:declSig $val:declVal)
+```
+
+Then `import MyProject.Blueprint` at the top of any file where you write lemmas. After that, `lemma foo : … := …` and `/-- … -/ lemma foo : … := …` render as `\begin{lemma}` under `blueprint.all` with no per-declaration tags. Apply the same shape to `proposition`/`corollary` (or any other keyword you define) as needed. This recipe is intentionally kept project-side: the right keyword set is opinionated and the recipe avoids coupling LeanArchitect to Mathlib's surface syntax.
+
+**Scope.** The recipe above covers bare and docstring'd lemmas — the typical blueprint case. It does *not* match lemmas with other modifiers (`private`, `noncomputable`, a pre-existing `@[…]`); for those, fall back to the per-declaration override.
+
 ## Progress statistics
 
 To view formalization progress, use the `#blueprint_progress` command in Lean:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ so that the `\input` line above works. Here are some typical examples for doing 
 
 ## Auto-blueprinting
 
-By default, each declaration must be tagged with `@[blueprint]` to appear in the blueprint. To automatically include all declarations with docstrings, use:
+By default, each declaration must be tagged with `@[blueprint]` to appear in the blueprint. To automatically include all declarations with docstrings, set `blueprint.all`:
 
 ```lean
 set_option blueprint.all true
@@ -234,7 +234,7 @@ theorem helper : ... := ...               -- NOT included (no docstring)
 
 The statement text comes from the docstring, dependencies are auto-inferred, and the LaTeX environment is determined by the declaration kind (theorem → `theorem`, def/inductive → `definition`).
 
-To override specific options for a declaration, add `@[blueprint ...]` explicitly — it takes precedence over auto-mode:
+To override specific options for a declaration, add `@[blueprint ...]` explicitly — it takes precedence over auto-mode. An explicit `@[blueprint]` with no `statement := ...` also uses the declaration's docstring as its statement:
 
 ```lean
 /-- Fermat's last theorem. -/
@@ -242,7 +242,24 @@ To override specific options for a declaration, add `@[blueprint ...]` explicitl
 theorem flt : ... := ...
 ```
 
-Note: `blueprint.all` only affects the current file. Imported modules are not auto-blueprinted.
+### Enabling `blueprint.all` for the generated blueprint
+
+`set_option blueprint.all true` written inside a `.lean` file only affects that file *interactively* (e.g. `#blueprint_progress`); it is not visible to `lake build :blueprint`, which runs as a separate process. To auto-blueprint a library in the generated blueprint, set the option in your `lakefile`'s `leanOptions` instead (this also drives the interactive commands, so you don't need the `set_option` line):
+
+```lean
+-- lakefile.lean
+lean_lib MyProject where
+  leanOptions := #[⟨`blueprint.all, true⟩]
+```
+
+```toml
+# lakefile.toml
+[[lean_lib]]
+name = "MyProject"
+leanOptions = [{ name = "blueprint.all", value = true }]
+```
+
+Note: `blueprint.all` only auto-blueprints the modules it is applied to; declarations from imported libraries (e.g. Mathlib) are never auto-blueprinted.
 
 ## Progress statistics
 


### PR DESCRIPTION
Add interactive and CLI commands for tracking formalization progress, plus an auto-blueprinting mode.

### Demo

https://github.com/user-attachments/assets/84129c9e-bea7-4183-96af-9ae9aa0596ca

### Progress tracking

4 new commands, each with a corresponding CLI subcommand:

| Command | Purpose |
|---|---|
| `#blueprint_progress` | Aggregated formalization stats with optional per-module breakdown |
| `#blueprint_incomplete` | Incomplete nodes sorted by dependency completion |
| `#blueprint_status <node_name>` | A node's status and its blocking dependencies |
| `#blueprint_impact <node_name>` | Reverse dependencies and what formalizing a node would unblock |

All support a `local` modifier to restrict scope to the current file/given modules.

### Auto-blueprinting

`set_option blueprint.all true` includes all declarations with docstrings in the blueprint without requiring `@[blueprint]` tags. The docstring becomes the statement text, the LaTeX environment is inferred from the declaration kind, and explicit `@[blueprint ...]` takes precedence. Scope is current file only.

Co-authored-by: Claude (Opus 4.6) <claude@anthropic.com>

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)